### PR TITLE
Added tooltips to Forecasting

### DIFF
--- a/global.R
+++ b/global.R
@@ -55,6 +55,9 @@ options(spinner.type = 5)
 options(spinner.color = "#c8c8c8")
 options(spinner.size = .5)
 
+seq_gradient <- c("#8c2d04","#cc4c02","#ec7014","#fe9929","#fec44f","#d9f0a3")
+divergent_gradient <- c(seq_gradient,rev(seq_gradient))
+
 
 # Enable bookmarking ---------------------------------------------------------
 

--- a/server.R
+++ b/server.R
@@ -182,10 +182,15 @@ function(input, output, session) {
       x = ~LA_name, y = ~QuanIn,
       marker = list(color = c("#12436D")),
       type = "bar", name = paste0("Total places created between 2009/10 and ", this_year),
-      text = ~ scales::comma(QuanIn), textposition = "inside", textfont = list(color = "#FFF")
-    ) %>%
-      add_trace(y = ~QuanPP, marker = list(color = c("#F46A25")), name = paste0("New places already planned for delivery between ", this_year, " and ", plan_year), text = ~ scales::comma(QuanPP), textposition = "inside") %>%
-      add_trace(y = ~QuanRP, marker = list(color = c("#801650")), name = paste0("Estimated additional places still needed to meet demand in ", plan_year), text = ~ scales::comma(QuanRP), textposition = "inside") %>%
+      text = ~ scales::comma(QuanIn), textposition = "inside", textfont = list(color = "#FFF"),
+      hoverinfo="text"
+      ) %>%
+      add_trace(y = ~QuanPP, marker = list(color = c("#F46A25")), 
+                name = paste0("New places planned for delivery between ", this_year, " and ", plan_year), 
+                text = ~ scales::comma(QuanPP), textposition = "inside") %>%
+      add_trace(y = ~QuanRP, marker = list(color = c("#801650")), 
+                name = paste0("Estimated additional places still needed to meet demand in ", plan_year), 
+                text = ~ scales::comma(QuanRP), textposition = "inside") %>%
       layout(
         yaxis = list(title = ""),
         xaxis = list(title = ""),
@@ -254,7 +259,7 @@ function(input, output, session) {
     tagList(p(paste0("The filled bar in each chart shows the forecasting accuracy for ", input$LA_choice, ".")))
   )
 
-  output$forecast_1y_bar <- renderPlot(
+  output$forecast_1y_bar <- renderPlotly(
     {
       forecast_accuracy <- live_scorecard_data() %>%
         filter(name == "For_1") %>%
@@ -278,12 +283,14 @@ function(input, output, session) {
 
       range_values$accuracy[5] <- (ceiling(range_values$accuracy[5]))
       range_values$accuracy[0] <- (ceiling(abs(range_values$accuracy[0])) * range_values$accuracy[0] / abs(range_values$accuracy[0]))
-      ggplot(forecast_accuracy, aes(name, value, fill = value)) +
+      p <- ggplot(forecast_accuracy, 
+                  aes(name, value, fill = value,
+                      text=paste0(input$LA_choice,": ", value,"%"))) +
         geom_bar(stat = "identity", width = 100) +
-        scale_fill_gradient2(
-          low = "#e34a33", mid = "#e0f3db", high = "#e34a33",
+        scale_fill_gradientn(
+          colors=divergent_gradient,
           space = "Lab",
-          limits = c(-abs(range_values$accuracy[1]), abs(range_values$accuracy[5]))
+          limits = c(-0.75*abs(range_values$accuracy[5]), 1.08*abs(range_values$accuracy[5])),
         ) +
         ylim(-0.33 * range_values$accuracy[5], range_values$accuracy[5]) +
         theme_bw() +
@@ -294,17 +301,17 @@ function(input, output, session) {
         ) +
         geom_hline(yintercept = 0, linetype = "dotted") +
         geom_hline(yintercept = range_values$accuracy[2], linetype = "dashed") +
-        geom_hline(yintercept = 100. * (forecast_range %>% filter(LA_name == "England"))$value, size = 2) +
+        geom_hline(yintercept = 100. * (forecast_range %>% filter(LA_name == "England"))$value, size = 1.4) +
         geom_hline(yintercept = range_values$accuracy[4], linetype = "dashed") +
         geom_hline(yintercept = forecast_accuracy$value) +
         labs(x = "", y = "Accuracy (%)") +
         coord_flip()
-    },
-    height = 96,
-    width = "auto"
+      ggplotly(p, tooltip=c("text")) %>%
+        config(displayModeBar = FALSE)
+    }
   )
 
-  output$forecast_3y_bar <- renderPlot(
+  output$forecast_3y_bar <- renderPlotly(
     {
       forecast_accuracy <- live_scorecard_data() %>%
         filter(name == "For_3")
@@ -326,12 +333,12 @@ function(input, output, session) {
       range_values$accuracy[5] <- (ceiling(range_values$accuracy[5]))
       range_values$accuracy[0] <- (ceiling(abs(range_values$accuracy[0])) * range_values$accuracy[0] / abs(range_values$accuracy[0]))
 
-      ggplot(forecast_accuracy, aes(name, value, fill = value)) +
+      p <- ggplot(forecast_accuracy, aes(name, value, fill = value, text=paste0(input$LA_choice,": ", value,"%"))) +
         geom_bar(stat = "identity", width = 100) +
-        scale_fill_gradient2(
-          low = "#e34a33", mid = "#e0f3db", high = "#e34a33",
+        scale_fill_gradientn(
+          colors=divergent_gradient,
           space = "Lab",
-          limits = c(-abs(range_values$accuracy[1]), abs(range_values$accuracy[5]))
+          limits = c(-0.75*abs(range_values$accuracy[5]), 1.08*abs(range_values$accuracy[5])),
         ) +
         ylim(c(-0.33 * range_values$accuracy[5], range_values$accuracy[5])) +
         theme_bw() +
@@ -342,14 +349,14 @@ function(input, output, session) {
         ) +
         geom_hline(yintercept = 0, linetype = "dotted") +
         geom_hline(yintercept = range_values$accuracy[2], linetype = "dashed") +
-        geom_hline(yintercept = 100. * (forecast_range %>% filter(LA_name == "England"))$value, size = 2) +
+        geom_hline(yintercept = 100. * (forecast_range %>% filter(LA_name == "England"))$value, size = 1.4) +
         geom_hline(yintercept = range_values$accuracy[4], linetype = "dashed") +
         geom_hline(yintercept = forecast_accuracy$value) +
         labs(x = "", y = "Accuracy (%)") +
         coord_flip()
-    },
-    height = 96,
-    width = "auto"
+      ggplotly(p, tooltip=c("text")) %>%
+        config(displayModeBar = FALSE)
+    }
   )
 
 
@@ -469,6 +476,7 @@ function(input, output, session) {
         )
       ) %>%
       config(displayModeBar = FALSE)
+    
   })
 
   # Quality -----------------------------------------------------------------

--- a/ui.R
+++ b/ui.R
@@ -80,10 +80,10 @@ function(request) {
                   uiOutput("forecasting.bartext"),
                   htmlOutput("label_estimate_y1"),
                   br(),
-                  plotOutput("forecast_1y_bar", height = "96px"),
+                  plotlyOutput("forecast_1y_bar", height = "120px"),
                   htmlOutput("label_estimate_y3"),
                   br(),
-                  plotOutput("forecast_3y_bar", height = "96px"),
+                  plotlyOutput("forecast_3y_bar", height = "120px"),
                 )
               )
             ),


### PR DESCRIPTION
## Updates
* Added tooltip/hoverinfo to forecasting bar charts - displays the area and percentage accuracy when you hover over the colour-filled bar.
* Adjusted the scaling on both forecasting charts so that it's not green at any accuracies of <0%.
* Simplified hoverinfo on the school places stacked bar chart to just show the number of places in each category.

## Forecast bar charts

Put the ggplot() inside a ggplotly() environment and fed the tooltip option the formatted text. Also changed the fill scale from low/mid/high to an array with _gradientn. Should be green near to the England average and goes orange around the 25th/75th percentiles (ish).

<img width="357" alt="Forecasting_bar_tooltip_Barnsley" src="https://user-images.githubusercontent.com/230859/173577827-dd30a890-5c03-4c99-99ee-25956aa6162b.PNG">

<img width="363" alt="Forecasting_bar_tooltip_Hammersmith" src="https://user-images.githubusercontent.com/230859/173577847-2b176b7b-3268-4284-9bb7-357e9bd1c031.PNG">

## School places chart

The tooltip on the places barchart was too long and was getting cut off. Have simplified it to just give the number of places (all the other information is clearly provided in the legend and text).

<img width="345" alt="Places_bar_tooltip" src="https://user-images.githubusercontent.com/230859/173578492-e3f9622c-ba4c-49ed-abf6-7fb6a474ede7.PNG">

