### PR TITLE
Added example tooltip code for input features

### DIFF
--- a/global.R
+++ b/global.R
@@ -22,6 +22,7 @@ library(metathis)
 library(shinyWidgets)
 library(styler)
 library(rsconnect)
+library(shinyBS)
 
 # tidy_code_function -------------------------------------------------------------------------------
 

--- a/server.R
+++ b/server.R
@@ -1395,7 +1395,8 @@ function(input, output, session) {
     }
   })
 
-  # Automatically bookmark every time an input changes-------------------
+
+    # Automatically bookmark every time an input changes-------------------
   observe({
     reactiveValuesToList(input)
     session$doBookmark()

--- a/ui.R
+++ b/ui.R
@@ -31,11 +31,17 @@ function(request) {
             label = p(strong("Choose a geography")),
             choices = levels(LA_options)
           ),
+          bsTooltip("LA_choice", 
+                    "Please select your required geography level.",
+                    "right"),
           br(),
           selectInput("phase_choice",
             label = p(strong("Choose a phase")),
             choices = c("Primary", "Secondary")
           ),
+          bsTooltip("phase_choice", 
+                    "Please select your required phase.",
+                    "right"),
           br(),
           selectInput("chart_choice",
             label = p(strong("Choose a quality measure")),


### PR DESCRIPTION
Here's the example code:

`bsTooltip("phase_choice", "Please select your required phase.", "right")`

The first argument ("phase_choice") is the ID of the shiny component you want the tooltip to appear by when you hover over it. The second argument is the text that appears and the third is the position relative the shiny component. I've applied it to the top two selectInput boxes in the app as an example.

<img width="184" alt="tootip_LAchoice" src="https://user-images.githubusercontent.com/230859/174293398-6028d4f1-257a-4a8d-ae8b-b14ecb75542d.PNG">

Have created this pull request partially just so you can see the code in situ under the files changed tab above or in action if you want to switch on to this branch.