### PR TITLE
Fix markdown tables

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -1,0 +1,3 @@
+format_perc <- function(x){
+  paste0(sprintf("%+.1f",100.*roundFiveUp(x,3)), "%") 
+}

--- a/Summary_scorecard.Rmd
+++ b/Summary_scorecard.Rmd
@@ -16,6 +16,7 @@ header-includes:
    - \usepackage{sectsty}
    - \usepackage{fancyhdr}
    - \usepackage{xpatch}
+   - \usepackage{booktabs}
    - \pagestyle{fancy}
    - \definecolor{gssmidblue}{RGB}{32, 115, 188}
    - \definecolor{dfeheadingblue}{RGB}{16, 79, 117}
@@ -40,8 +41,17 @@ urlcolor: blue
 knitr::opts_chunk$set(echo = FALSE)
 knitr::knit_hooks$set(crop = knitr::hook_pdfcrop)
 source("global.R")
-library(webshot)
-library(kableExtra)
+
+# Filter the data
+# dfScorecardsAll contains the data for all LAs for the selected phase.
+dfScorecardsAll <- scorecards_data_pivot %>% filter(
+    Phase == params$input_phase_choice
+  )
+# dfScorecardArea contains only the data for the selected LA (for the selected phase).
+dfScorecardArea <- scorecards_data_pivot %>% filter(
+    LA_name == params$input_la_choice,
+    Phase == params$input_phase_choice
+  )
 
 ```
 
@@ -81,13 +91,8 @@ This document presents school places figures for `r params$input_la_choice` cove
       ) %>%
       as.numeric()
 
-# Take filtered data, search for growth rate, pull the value and tidy the number up
-  live_scorecard_data <- scorecards_data_pivot %>% filter(
-      LA_name == params$input_la_choice,
-      Phase == params$input_phase_choice
-    )
   
-    growth_perc <- live_scorecard_data %>%
+    growth_perc <- dfScorecardArea %>%
       filter(name == "Bangro") %>%
       pull(value) %>%
       roundFiveUp(., 2) * 100
@@ -156,7 +161,7 @@ A local authority can have both ‘spare places’ and ‘additional places need
   ## Estimated places need
 
     # Take filtered data, search for growth rate, pull the value and tidy the number up
-    additional_places_perc <- live_scorecard_data %>%
+    additional_places_perc <- dfScorecardArea %>%
       filter(name == "QuanRP") %>%
       pull(value)
 
@@ -168,7 +173,7 @@ A local authority can have both ‘spare places’ and ‘additional places need
   ## Estimated spare places
 
     # Take filtered data, search for growth rate, pull the value and tidy the number up
-    spare_places_per <- live_scorecard_data %>%
+    spare_places_per <- dfScorecardArea %>%
       filter(name == "QuanSu") %>%
       pull(value) %>%
       roundFiveUp(., 2) * 100
@@ -211,11 +216,7 @@ Estimated percentage of spare `r str_to_lower(params$input_phase_choice)` places
 }
 
 ``` {r quantity_b, echo = FALSE, fig.show="hold", out.width = "100%",crop=TRUE}
- live_scorecard_data <- scorecards_data_pivot %>% filter(
-      LA_name == params$input_la_choice,
-      Phase == params$input_phase_choice)
-
-    places_chart_data <- live_scorecard_data %>%
+places_chart_data <- dfScorecardArea %>%
       filter(name %in% c("QuanIn", "QuanPP", "QuanRP")) %>%
       select(LA_name, name, value) %>%
       pivot_wider()  
@@ -261,17 +262,15 @@ The grey dashed lines show the 25th and 75th percentile score for all local auth
    ## Forecast accuracy labels 
 
   
-     forecast_accuracy <- live_scorecard_data %>% 
+     forecast_accuracy <- dfScorecardArea %>% 
        filter(name == "For_1") %>% 
        pull(value) %>% 
        roundFiveUp(., 3) * 100 
 
 
-     Foracc1year <- scorecards_data_pivot %>% 
-       filter( 
-         name == "For_1", 
-         Phase == params$input_phase_choice)  %>% 
-             pull(value) %>% 
+     Foracc1year <- dfScorecardsAll %>% 
+       filter(name == "For_1")  %>% 
+       pull(value) %>% 
        roundFiveUp(., 3) * 100 
 
      medianaccuracy1 <- median(Foracc1year, na.rm = TRUE)  
@@ -303,7 +302,7 @@ The grey dashed lines show the 25th and 75th percentile score for all local auth
 
 ```
 
-## `r oneyearlabel`
+### `r oneyearlabel`
  `r label1`
 
   
@@ -312,17 +311,14 @@ The grey dashed lines show the 25th and 75th percentile score for all local auth
 ``` {r forecast1,echo = FALSE, warning = FALSE, message=FALSE, results='asis', fig.height=1}
 
 
-     forecast_accuracy <- live_scorecard_data %>%
+     forecast_accuracy <- dfScorecardArea %>%
       filter(name == "For_1") %>%
       as.data.frame()
 
     forecast_accuracy$value <- forecast_accuracy$value %>% roundFiveUp(., 3) * 100
 
-    forecast_range <- scorecards_data_pivot %>%
-      filter(
-        name == "For_1",
-        Phase == params$input_phase_choice
-      )
+    forecast_range <- dfScorecardsAll %>%
+      filter(name == "For_1")
 
 
     range_values <- forecast_range %>%
@@ -365,45 +361,34 @@ The grey dashed lines show the 25th and 75th percentile score for all local auth
 
 ```
  
- Range of accuracy scores one year ahead
+The table below shows the range in accuracy scores one year ahead across all England LAs
  
 ``` {r forecast3,echo = FALSE, warning = FALSE, message=FALSE, results='asis'}
   facc_table1 <- 
-     scorecards_data_pivot %>% 
-       filter( 
-         name == "For_1", 
-         Phase == params$input_phase_choice 
-       ) %>% 
+     dfScorecardsAll %>% 
+       filter(name == "For_1") %>% 
        mutate( 
-         Median  = median(value, na.rm = TRUE), 
-         Median =  roundFiveUp(Median,3) * 100, 
-         Median =   paste0(Median, "%"), 
-         Twentyfifthpercentile = quantile(value,0.25, na.rm = TRUE), 
-         Twentyfifthpercentile =  roundFiveUp(Twentyfifthpercentile,3) * 100, 
-         Twentyfifthpercentile =   paste0( Twentyfifthpercentile, "%"), 
-         Seventyfifthpercentile = quantile(value,0.75, na.rm = TRUE), 
-         Seventyfifthpercentile =  roundFiveUp(Seventyfifthpercentile,3) * 100, 
-         Seventyfifthpercentile =   paste0(Seventyfifthpercentile, "%"), 
-         Minimum = min(value, na.rm = TRUE), 
-         Minimum =  roundFiveUp(Minimum,3) * 100, 
-         Minimum =   paste0(Minimum, "%"), 
-         Maximum = max(value, na.rm = TRUE), 
-         Maximum =  roundFiveUp(Maximum,3) * 100, 
-         Maximum =   paste0(Maximum, "%") 
+         Median  = format_perc(median(value, na.rm = TRUE)), 
+         Twentyfifthpercentile = format_perc(quantile(value,0.25, na.rm = TRUE)), 
+         Seventyfifthpercentile = format_perc(quantile(value,0.75, na.rm = TRUE)), 
+         Minimum = format_perc(min(value, na.rm = TRUE)), 
+         Maximum = format_perc(max(value, na.rm = TRUE)), 
         ) %>% 
-       filter( 
-                LA_name == "England" 
-       ) %>% 
-     select(Minimum, Twentyfifthpercentile, Median,  Seventyfifthpercentile, Maximum) 
-
- kable(facc_table1)
+       filter(LA_name == "England") %>%  
+     select(` `=LA_name,
+            Minimum, 
+            `25th percentile`=Twentyfifthpercentile, 
+            Median, 
+            `75th percentile`=Seventyfifthpercentile, 
+            Maximum)
+kable(facc_table1,"latex",booktabs = T)
 ```
  
 
  
 ``` {r forecast5,echo = FALSE, warning = FALSE, message=FALSE, results='asis'}
   
-     forecast_accuracy <- live_scorecard_data %>% 
+     forecast_accuracy <- dfScorecardArea %>% 
        filter(name == "For_3") %>% 
        pull(value) %>% 
        roundFiveUp(., 3) * 100 
@@ -440,23 +425,14 @@ The grey dashed lines show the 25th and 75th percentile score for all local auth
      } else { 
        paste("<b>Three years ahead : </b>", label) 
      } 
-   
 
-
-   
 ``` 
  
-## `r threeyearlabel`
+### `r threeyearlabel`
  `r label`
 
-
-
-
-
 ``` {r forecast22,echo = FALSE, warning = FALSE, message=FALSE, results='asis', fig.height=1}
- 
-
-     forecast_accuracy <- live_scorecard_data %>% 
+     forecast_accuracy <- dfScorecardArea %>% 
        filter(name == "For_3") 
 
      forecast_accuracy$value <- forecast_accuracy$value %>% roundFiveUp(., 3) * 100 
@@ -498,45 +474,30 @@ The grey dashed lines show the 25th and 75th percentile score for all local auth
        geom_hline(yintercept = forecast_accuracy$value, size = 1.) + 
        labs(x = "", y = "Accuracy (%)") + 
        coord_flip() 
-     
-       
-
 ```
 
-Range of accuracy scores three years ahead
+The table below shows the range in accuracy scores three years ahead across all England LAs
  
 ``` {r forecast4,echo = FALSE, warning = FALSE, message=FALSE, results='asis'}
   facc_table3 <- 
-     scorecards_data_pivot %>% 
-       filter( 
-         name == "For_3", 
-         Phase == params$input_phase_choice 
-       ) %>% 
+     dfScorecardsAll %>% 
+       filter(name == "For_3") %>% 
        mutate( 
-         Median  = median(value, na.rm = TRUE), 
-         Median =  roundFiveUp(Median,3) * 100, 
-         Median =   paste0(Median, "%"), 
-         Twentyfifthpercentile = quantile(value,0.25, na.rm = TRUE), 
-         Twentyfifthpercentile =  roundFiveUp(Twentyfifthpercentile,3) * 100, 
-         Twentyfifthpercentile =   paste0( Twentyfifthpercentile, "%"), 
-         Seventyfifthpercentile = quantile(value,0.75, na.rm = TRUE), 
-         Seventyfifthpercentile =  roundFiveUp(Seventyfifthpercentile,3) * 100, 
-         Seventyfifthpercentile =   paste0(Seventyfifthpercentile, "%"), 
-         Minimum = min(value, na.rm = TRUE), 
-         Minimum =  roundFiveUp(Minimum,3) * 100, 
-         Minimum =   paste0(Minimum, "%"), 
-         Maximum = max(value, na.rm = TRUE), 
-         Maximum =  roundFiveUp(Maximum,3) * 100, 
-         Maximum =   paste0(Maximum, "%") 
-       ) %>% 
+         Median  = format_perc(median(value, na.rm = TRUE)), 
+         Twentyfifthpercentile = format_perc(quantile(value,0.25, na.rm = TRUE)), 
+         Seventyfifthpercentile = format_perc(quantile(value,0.75, na.rm = TRUE)), 
+         Minimum = format_perc(min(value, na.rm = TRUE)), 
+         Maximum = format_perc(max(value, na.rm = TRUE)), 
+        ) %>% 
        filter( 
-         LA_name == "England" 
-       ) %>% 
-       select(Minimum, Twentyfifthpercentile, Median,  Seventyfifthpercentile, Maximum) 
-     
-  
-    kable(facc_table3) 
- 
+                LA_name == "England" 
+       ) %>%  
+     select(` `=LA_name,
+            Minimum, 
+            `25th percentile`=Twentyfifthpercentile, 
+            Median, `75th percentile`=Seventyfifthpercentile, Maximum) 
+
+ kable(facc_table3,"latex",booktabs = T)
 ```
 
 \newpage
@@ -547,18 +508,18 @@ Range of accuracy scores three years ahead
 
 ```{r preference_text, echo = FALSE, message=FALSE}
 
-live_scorecard_data_all_la <- scorecards_data_pivot %>% filter(Phase == params$input_phase_choice)
+dfScorecardArea_all_la <- scorecards_data_pivot %>% filter(Phase == params$input_phase_choice)
 
 
     # Take filtered data, search for growth rate, pull the value and tidy the number up
-    PrefT3_E <- live_scorecard_data_all_la %>%
+    PrefT3_E <- dfScorecardArea_all_la %>%
       filter(name == "PrefT3") %>%
       filter(LA_name == "England") %>%
       pull(value) %>%
       roundFiveUp(., 1)
 
       # Take filtered data, search for growth rate, pull the value and tidy the number up
-    PrefT3 <- live_scorecard_data %>%
+    PrefT3 <- dfScorecardArea %>%
       filter(name == "PrefT3") %>%
       pull(value) %>%
       roundFiveUp(., 1)
@@ -612,7 +573,7 @@ cat("
 
 ```{r preference_barchart, echo = FALSE, message=FALSE, out.width="100%", crop=TRUE}
 # Scorecard data, filtered on user input AND including England as a comparison
-  live_scorecard_data_england_comp <- scorecards_data_pivot %>%
+  dfScorecardArea_england_comp <- scorecards_data_pivot %>%
       filter(
         LA_name %in% c(params$input_la_choice, "England"),
         Phase == params$input_phase_choice
@@ -625,7 +586,7 @@ cat("
       )
   
     # reshape the data so it plots neatly!
-    preference_data <- live_scorecard_data_england_comp %>%
+    preference_data <- dfScorecardArea_england_comp %>%
       # select only preference values
       filter(name %in% c("Pref1", "Pref2", "Pref3")) %>%
       # Create ratings out of the names
@@ -712,41 +673,41 @@ cat("
   # Calculate LA % depending on chart choice:
   LA_comp <- 
     if (params$input_quality_chart == "Ofsted") {
-      live_scorecard_data %>%
+      dfScorecardArea %>%
         filter(name == "QualProp") %>%
         pull(value) %>%
         roundFiveUp(., 2) * 100
     } else if (params$input_quality_chart == "Progress 8") {
-      live_scorecard_data %>%
+      dfScorecardArea %>%
         filter(name == "Qual_KS4_Prop") %>%
         pull(value) %>%
         roundFiveUp(., 2) * 100
     } else if (params$input_quality_chart == "Reading Progress") {
-      live_scorecard_data %>%
+      dfScorecardArea %>%
         filter(name == "Qual_KS2Read_Prop") %>%
         pull(value) %>%
         roundFiveUp(., 2) * 100
     } else if (params$input_quality_chart== "Maths Progress") {
-      live_scorecard_data %>%
+      dfScorecardArea %>%
         filter(name == "Qual_KS2Mat_Prop") %>%
         pull(value) %>%
         roundFiveUp(., 2) * 100
     }
   
              # Scorecard data for ALL LAs, filtered only on phase choice
-live_scorecard_data_all_la <- scorecards_data_pivot %>% filter(Phase == params$input_phase_choice)
+dfScorecardArea_all_la <- scorecards_data_pivot %>% filter(Phase == params$input_phase_choice)
  
         
   # Calculate England comparator depending on chart choice:
   england_comp <- 
     if (params$input_quality_chart == "Ofsted") {
-      numerator <- live_scorecard_data_all_la %>%
+      numerator <- dfScorecardArea_all_la %>%
         filter(LA_name == "England" &
           name %in% c("Qual1_N", "Qual2_N")) %>%
         summarise(sum(value)) %>%
         as.numeric()
 
-      denominator <- live_scorecard_data_all_la %>%
+      denominator <- dfScorecardArea_all_la %>%
         filter(LA_name == "England" &
           name %in% c("Qual1_N", "Qual2_N", "Qual3_N", "Qual4_N")) %>%
         summarise(sum(value)) %>%
@@ -755,13 +716,13 @@ live_scorecard_data_all_la <- scorecards_data_pivot %>% filter(Phase == params$i
       # calculate percentage
       roundFiveUp(numerator / denominator * 100, 1)
     } else if (params$input_quality_chart == "Progress 8") {
-      numerator <- live_scorecard_data_all_la %>%
+      numerator <- dfScorecardArea_all_la %>%
         filter(LA_name == "England" &
           name %in% c("KS4_WAA_N", "KS4_AA_N")) %>%
         summarise(sum(value)) %>%
         as.numeric()
 
-      denominator <- live_scorecard_data_all_la %>%
+      denominator <- dfScorecardArea_all_la %>%
         filter(LA_name == "England" &
           name %in% c("KS4_WAA_N", "KS4_AA_N", "KS4_A_N", "KS4_BA_N", "KS4_WBA_N")) %>%
         summarise(sum(value)) %>%
@@ -770,13 +731,13 @@ live_scorecard_data_all_la <- scorecards_data_pivot %>% filter(Phase == params$i
       # calculate percentage
       roundFiveUp(numerator / denominator * 100, 1)
     } else if (params$input_quality_chart == "Reading Progress") {
-      numerator <- live_scorecard_data_all_la %>%
+      numerator <- dfScorecardArea_all_la %>%
         filter(LA_name == "England" &
           name %in% c("KS2Read_WAA_N", "KS2Read_AA_N")) %>%
         summarise(sum(value)) %>%
         as.numeric()
 
-      denominator <- live_scorecard_data_all_la %>%
+      denominator <- dfScorecardArea_all_la %>%
         filter(LA_name == "England" &
           name %in% c("KS2Read_WAA_N", "KS2Read_AA_N", "KS2Read_A_N", "KS2Read_BA_N", "KS2Read_WBA_N")) %>%
         summarise(sum(value)) %>%
@@ -785,13 +746,13 @@ live_scorecard_data_all_la <- scorecards_data_pivot %>% filter(Phase == params$i
       # calculate percentage
       roundFiveUp(numerator / denominator * 100, 1)
     } else if (params$input_quality_chart == "Maths Progress") {
-      numerator <- live_scorecard_data_all_la %>%
+      numerator <- dfScorecardArea_all_la %>%
         filter(LA_name == "England" &
           name %in% c("KS2Mat_WAA_N", "KS2Mat_AA_N")) %>%
         summarise(sum(value)) %>%
         as.numeric()
 
-      denominator <- live_scorecard_data_all_la %>%
+      denominator <- dfScorecardArea_all_la %>%
         filter(LA_name == "England" &
           name %in% c("KS2Mat_WAA_N", "KS2Mat_AA_N", "KS2Mat_A_N", "KS2Mat_BA_N", "KS2Mat_WBA_N")) %>%
         summarise(sum(value)) %>%
@@ -804,19 +765,19 @@ live_scorecard_data_all_la <- scorecards_data_pivot %>% filter(Phase == params$i
             # Calculate % ranking depending on chart choice:
   LA_ranking <- 
     if (params$input_quality_chart == "Ofsted") {
-      live_scorecard_data %>%
+      dfScorecardArea %>%
         filter(name == "QualPropranks") %>%
         pull(value)
     } else if (params$input_quality_chart == "Progress 8") {
-      live_scorecard_data %>%
+      dfScorecardArea %>%
         filter(name == "Qual_KS4_Propranks") %>%
         pull(value)
     } else if (params$input_quality_chart == "Reading Progress") {
-      live_scorecard_data %>%
+      dfScorecardArea %>%
         filter(name == "Qual_KS2Read_Propranks") %>%
         pull(value)
     } else if (params$input_quality_chart == "Maths Progress") {
-      live_scorecard_data %>%
+      dfScorecardArea %>%
         filter(name == "Qual_KS2Mat_Propranks") %>%
         pull(value)
     }
@@ -824,19 +785,19 @@ live_scorecard_data_all_la <- scorecards_data_pivot %>% filter(Phase == params$i
     # Calculate ranking denominator depending on chart choice:
   LA_denom <- 
     if (params$input_quality_chart == "Ofsted") {
-      live_scorecard_data_all_la %>%
+      dfScorecardArea_all_la %>%
         filter(name == "QualPropranks" & !is.na(value)) %>%
         nrow()
     } else if (params$input_quality_chart == "Progress 8") {
-      live_scorecard_data_all_la %>%
+      dfScorecardArea_all_la %>%
         filter(name == "Qual_KS4_Propranks" & !is.na(value)) %>%
         nrow()
     } else if (params$input_quality_chart == "Reading Progress") {
-      live_scorecard_data_all_la %>%
+      dfScorecardArea_all_la %>%
         filter(name == "Qual_KS2Read_Propranks" & !is.na(value)) %>%
         nrow()
     } else if (params$input_quality_chart == "Maths Progress") {
-      live_scorecard_data_all_la %>%
+      dfScorecardArea_all_la %>%
         filter(name == "Qual_KS2Mat_Propranks" & !is.na(value)) %>%
         nrow()
     }
@@ -904,7 +865,7 @@ LA Rank out of ", LA_denom, " LAs that created new places between ", last_year, 
 
 ``` {r quality_chart, out.width="92%", crop=TRUE}           
 # Scorecard data, filtered on user input AND including England as a comparison
-  live_scorecard_data_england_comp <- scorecards_data_pivot %>%
+  dfScorecardArea_england_comp <- scorecards_data_pivot %>%
       filter(
         LA_name %in% c(params$input_la_choice, "England"),
         Phase == params$input_phase_choice
@@ -919,7 +880,7 @@ LA Rank out of ", LA_denom, " LAs that created new places between ", last_year, 
  # Bar chart comparison - Ofsted
 
     # reshape the data so it plots neatly!
- ofsted_data <- live_scorecard_data_england_comp %>%
+ ofsted_data <- dfScorecardArea_england_comp %>%
       # select only the ofsted values
       filter(name %in% c(
         "Qual1_N", "Qual2_N", "Qual3_N", "Qual4_N", "Qual0_N",
@@ -985,7 +946,7 @@ LA Rank out of ", LA_denom, " LAs that created new places between ", last_year, 
     # Bar chart comparison - Progress 8
 
     # reshape the data so it plots neatly!
-    progress_8_data <- live_scorecard_data_england_comp %>%
+    progress_8_data <- dfScorecardArea_england_comp %>%
       # select only the progress 8 values
       filter(name %in% c(
         "KS4_WAA_N", "KS4_AA_N", "KS4_A_N", "KS4_BA_N", "KS4_WBA_N", "KS4_NR_N",
@@ -1051,7 +1012,7 @@ LA Rank out of ", LA_denom, " LAs that created new places between ", last_year, 
         # Bar chart comparison - Progress Reading
 
     # reshape the data so it plots neatly!
-    progress_reading_data <- live_scorecard_data_england_comp %>%
+    progress_reading_data <- dfScorecardArea_england_comp %>%
       # select only the reading values
       filter(name %in% c(
         "KS2Read_WAA_N", "KS2Read_AA_N", "KS2Read_A_N", "KS2Read_BA_N", "KS2Read_WBA_N", "KS2Read_NR_N",
@@ -1117,7 +1078,7 @@ LA Rank out of ", LA_denom, " LAs that created new places between ", last_year, 
     # Bar chart comparison - Progress Maths
 
     # reshape the data so it plots neatly!
-    progress_maths_data <- live_scorecard_data_england_comp %>%
+    progress_maths_data <- dfScorecardArea_england_comp %>%
       # select only the maths values
       filter(name %in% c(
         "KS2Mat_WAA_N", "KS2Mat_AA_N", "KS2Mat_A_N", "KS2Mat_BA_N", "KS2Mat_WBA_N", "KS2Mat_NR_N",
@@ -1244,7 +1205,7 @@ scorecards_data_pivot <- scorecards_data %>%
     name = str_replace_all(name, "_P$", "")
   )
 
-  live_scorecard_data_england_comp <- 
+  dfScorecardArea_england_comp <- 
     scorecards_data_pivot %>%
       filter(
         LA_name %in% c(params$input_la_choice, "England"),
@@ -1262,7 +1223,7 @@ scorecards_data_pivot <- scorecards_data %>%
 
  # Comparison boxes - number of projects 
  
-     perm_fig <- live_scorecard_data %>% 
+     perm_fig <- dfScorecardArea %>% 
       # Filter for Cost, places and project data 
       filter(str_detect(name, "Cost|Places|Projects")) %>% 
       # Create new column called data_type, based on the name of the data 
@@ -1283,7 +1244,7 @@ scorecards_data_pivot <- scorecards_data %>%
 
 
   
-    temp_fig <- live_scorecard_data %>% 
+    temp_fig <- dfScorecardArea %>% 
       # Filter for Cost, places and project data 
       filter(str_detect(name, "Cost|Places|Projects")) %>% 
       # Create new column called data_type, based on the name of the data 
@@ -1305,7 +1266,7 @@ scorecards_data_pivot <- scorecards_data %>%
   
 
  
-    new_fig <- live_scorecard_data %>% 
+    new_fig <- dfScorecardArea %>% 
       # Filter for Cost, places and project data 
       filter(str_detect(name, "Cost|Places|Projects")) %>% 
       # Create new column called data_type, based on the name of the data 
@@ -1404,7 +1365,7 @@ cost_text <-
   # Comparison table - average cost of projects per place
   
   cost_table <- 
-    live_scorecard_data_england_comp  %>%
+    dfScorecardArea_england_comp  %>%
       # Filter for Cost, places and project data
       filter(str_detect(name, "Cost|Places|Projects")) %>%
       # Create new column called data_type, based on the name of the data
@@ -1436,7 +1397,7 @@ cost_text <-
   
   
   
-  kable( cost_table)
+  kable( cost_table,"latex",booktabs = T)
   
   
 ```

--- a/Summary_scorecard.Rmd
+++ b/Summary_scorecard.Rmd
@@ -1392,11 +1392,6 @@ cost_text <-
       ) %>%
       select(Region, Type = exp_type, cost_per_place) %>%
       pivot_wider(names_from = Region, values_from = cost_per_place)
-  
-
-  
-  
-  
   kable( cost_table,"latex",booktabs = T)
   
   

--- a/global.R
+++ b/global.R
@@ -24,7 +24,7 @@ library(styler)
 library(rsconnect)
 library(bit64)
 library(webshot)
-webshot::install_phantomjs()
+webshot::install_phantomjs(force = FALSE)
 
 # tidy_code_function -------------------------------------------------------------------------------
 
@@ -37,6 +37,7 @@ tidy_code_function <- function() {
 }
 
 source("0_variable_change.R")
+source("R/functions.R")
 
 # ----------------------------------------------------------------------------
 # Setup loading screen and spinner

--- a/tests/shinytest/UI_tests-current/001.json
+++ b/tests/shinytest/UI_tests-current/001.json
@@ -1,0 +1,20 @@
+{
+  "input": {
+    "LA_choice": "Darlington",
+    "linkCostTab": 0,
+    "linkForecastTab": 0,
+    "linkPreferenceTab": 0,
+    "linkQualityTab": 0,
+    "linkQuantityTab": 0,
+    "navbar": "Homepage",
+    "phase_choice": "Primary",
+    "tabs": "Quantity",
+    "tabs_tech_notes": "Overall"
+  },
+  "output": {
+
+  },
+  "export": {
+
+  }
+}

--- a/tests/shinytest/UI_tests-current/002.json
+++ b/tests/shinytest/UI_tests-current/002.json
@@ -1,0 +1,285 @@
+{
+  "input": {
+    "LA_choice": "England",
+    "navbar": "la_scorecards",
+    "phase_choice": "Primary",
+    "tabs": "Quantity"
+  },
+  "output": {
+    "data_description": "Data for primary state funded school places in England: ",
+    "estimated_additional_places": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>40,970<\/h3>\n    <p>Estimated additional primary places needed to meet demand in 2021/22<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "estimated_spare_places": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>10%<\/h3>\n    <p>Estimated percentage of spare primary places in 2021/22<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "places_chart": {
+      "x": {
+        "layout": {
+          "margin": {
+            "b": 40,
+            "l": 60,
+            "t": 25,
+            "r": 10
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "title": ""
+          },
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "title": "",
+            "type": "category",
+            "categoryorder": "array",
+            "categoryarray": "England"
+          },
+          "barmode": "stack",
+          "uniformtext": {
+            "minsize": 12,
+            "mode": "hide"
+          },
+          "legend": {
+            "orientation": "h"
+          },
+          "font": {
+            "family": "Arial",
+            "size": 14
+          },
+          "title": {
+            "text": "Chart showing total places created, new places planned for delivery and estimated additional places needed to meet demand, by Local Authority compared to England",
+            "font": {
+              "color": "#ffffff"
+            }
+          },
+          "hovermode": "closest",
+          "showlegend": true
+        },
+        "source": "A",
+        "config": {
+          "showSendToCloud": false,
+          "displayModeBar": false
+        },
+        "data": [
+          {
+            "x": "England",
+            "y": 668942,
+            "marker": {
+              "color": "#12436D",
+              "line": {
+                "color": "rgba(31,119,180,1)"
+              }
+            },
+            "text": "668,942",
+            "textposition": "inside",
+            "textfont": {
+              "color": "#FFF"
+            },
+            "hoverinfo": "text",
+            "name": "Total places created between 2009/10 and 2018/19",
+            "type": "bar",
+            "error_y": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "error_x": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "x": "England",
+            "y": 66227,
+            "marker": {
+              "color": "#F46A25",
+              "line": {
+                "color": "rgba(255,127,14,1)"
+              }
+            },
+            "text": "66,227",
+            "textposition": "inside",
+            "textfont": {
+              "color": "#FFF"
+            },
+            "hoverinfo": "text",
+            "name": "New places planned for delivery between 2018/19 and 2021/22",
+            "type": "bar",
+            "error_y": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "error_x": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "x": "England",
+            "y": 40970,
+            "marker": {
+              "color": "#801650",
+              "line": {
+                "color": "rgba(44,160,44,1)"
+              }
+            },
+            "text": "40,970",
+            "textposition": "inside",
+            "textfont": {
+              "color": "#FFF"
+            },
+            "hoverinfo": "text",
+            "name": "Estimated additional places still needed to meet demand in 2021/22",
+            "type": "bar",
+            "error_y": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "error_x": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          }
+        ],
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
+      },
+      "evals": [
+
+      ],
+      "jsHooks": [
+
+      ],
+      "deps": [
+        {
+          "name": "setprototypeof",
+          "version": "0.1",
+          "src": {
+            "href": "setprototypeof-0.1"
+          },
+          "meta": null,
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "crosstalk",
+          "version": "1.1.1",
+          "src": {
+            "href": "crosstalk-1.1.1"
+          },
+          "meta": null,
+          "script": "js/crosstalk.min.js",
+          "stylesheet": "css/crosstalk.css",
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "plotly-htmlwidgets-css",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-htmlwidgets-css-1.57.1"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "plotly-main",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-main-1.57.1"
+          },
+          "meta": null,
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        }
+      ]
+    },
+    "pupil_growth": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>19%<\/h3>\n    <p>Growth in primary pupil numbers 2009/10 to 2021/22<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "total_funding_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>£12.3bn<\/h3>\n    <p>Total primary and secondary basic need funding 2011 to 2022<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/003.json
+++ b/tests/shinytest/UI_tests-current/003.json
@@ -1,0 +1,285 @@
+{
+  "input": {
+    "LA_choice": "Hertfordshire",
+    "navbar": "la_scorecards",
+    "phase_choice": "Primary",
+    "tabs": "Quantity"
+  },
+  "output": {
+    "data_description": "Data for primary state funded school places in Hertfordshire: ",
+    "estimated_additional_places": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>1,120<\/h3>\n    <p>Estimated additional primary places needed to meet demand in 2021/22<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "estimated_spare_places": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>10%<\/h3>\n    <p>Estimated percentage of spare primary places in 2021/22<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "places_chart": {
+      "x": {
+        "layout": {
+          "margin": {
+            "b": 40,
+            "l": 60,
+            "t": 25,
+            "r": 10
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "title": ""
+          },
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "title": "",
+            "type": "category",
+            "categoryorder": "array",
+            "categoryarray": "Hertfordshire"
+          },
+          "barmode": "stack",
+          "uniformtext": {
+            "minsize": 12,
+            "mode": "hide"
+          },
+          "legend": {
+            "orientation": "h"
+          },
+          "font": {
+            "family": "Arial",
+            "size": 14
+          },
+          "title": {
+            "text": "Chart showing total places created, new places planned for delivery and estimated additional places needed to meet demand, by Local Authority compared to England",
+            "font": {
+              "color": "#ffffff"
+            }
+          },
+          "hovermode": "closest",
+          "showlegend": true
+        },
+        "source": "A",
+        "config": {
+          "showSendToCloud": false,
+          "displayModeBar": false
+        },
+        "data": [
+          {
+            "x": "Hertfordshire",
+            "y": 16018,
+            "marker": {
+              "color": "#12436D",
+              "line": {
+                "color": "rgba(31,119,180,1)"
+              }
+            },
+            "text": "16,018",
+            "textposition": "inside",
+            "textfont": {
+              "color": "#FFF"
+            },
+            "hoverinfo": "text",
+            "name": "Total places created between 2009/10 and 2018/19",
+            "type": "bar",
+            "error_y": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "error_x": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "x": "Hertfordshire",
+            "y": 1323,
+            "marker": {
+              "color": "#F46A25",
+              "line": {
+                "color": "rgba(255,127,14,1)"
+              }
+            },
+            "text": "1,323",
+            "textposition": "inside",
+            "textfont": {
+              "color": "#FFF"
+            },
+            "hoverinfo": "text",
+            "name": "New places planned for delivery between 2018/19 and 2021/22",
+            "type": "bar",
+            "error_y": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "error_x": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "x": "Hertfordshire",
+            "y": 1120,
+            "marker": {
+              "color": "#801650",
+              "line": {
+                "color": "rgba(44,160,44,1)"
+              }
+            },
+            "text": "1,120",
+            "textposition": "inside",
+            "textfont": {
+              "color": "#FFF"
+            },
+            "hoverinfo": "text",
+            "name": "Estimated additional places still needed to meet demand in 2021/22",
+            "type": "bar",
+            "error_y": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "error_x": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          }
+        ],
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
+      },
+      "evals": [
+
+      ],
+      "jsHooks": [
+
+      ],
+      "deps": [
+        {
+          "name": "setprototypeof",
+          "version": "0.1",
+          "src": {
+            "href": "setprototypeof-0.1"
+          },
+          "meta": null,
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "crosstalk",
+          "version": "1.1.1",
+          "src": {
+            "href": "crosstalk-1.1.1"
+          },
+          "meta": null,
+          "script": "js/crosstalk.min.js",
+          "stylesheet": "css/crosstalk.css",
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "plotly-htmlwidgets-css",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-htmlwidgets-css-1.57.1"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "plotly-main",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-main-1.57.1"
+          },
+          "meta": null,
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        }
+      ]
+    },
+    "pupil_growth": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>19%<\/h3>\n    <p>Growth in primary pupil numbers 2009/10 to 2021/22<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "total_funding_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>£284m<\/h3>\n    <p>Total primary and secondary basic need funding 2011 to 2022<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/004.json
+++ b/tests/shinytest/UI_tests-current/004.json
@@ -1,0 +1,285 @@
+{
+  "input": {
+    "LA_choice": "Hertfordshire",
+    "navbar": "la_scorecards",
+    "phase_choice": "Secondary",
+    "tabs": "Quantity"
+  },
+  "output": {
+    "data_description": "Data for secondary state funded school places in Hertfordshire: ",
+    "estimated_additional_places": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>1,090<\/h3>\n    <p>Estimated additional secondary places needed to meet demand in 2021/22<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "estimated_spare_places": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>12%<\/h3>\n    <p>Estimated percentage of spare secondary places in 2021/22<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "places_chart": {
+      "x": {
+        "layout": {
+          "margin": {
+            "b": 40,
+            "l": 60,
+            "t": 25,
+            "r": 10
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "title": ""
+          },
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "title": "",
+            "type": "category",
+            "categoryorder": "array",
+            "categoryarray": "Hertfordshire"
+          },
+          "barmode": "stack",
+          "uniformtext": {
+            "minsize": 12,
+            "mode": "hide"
+          },
+          "legend": {
+            "orientation": "h"
+          },
+          "font": {
+            "family": "Arial",
+            "size": 14
+          },
+          "title": {
+            "text": "Chart showing total places created, new places planned for delivery and estimated additional places needed to meet demand, by Local Authority compared to England",
+            "font": {
+              "color": "#ffffff"
+            }
+          },
+          "hovermode": "closest",
+          "showlegend": true
+        },
+        "source": "A",
+        "config": {
+          "showSendToCloud": false,
+          "displayModeBar": false
+        },
+        "data": [
+          {
+            "x": "Hertfordshire",
+            "y": 10668,
+            "marker": {
+              "color": "#12436D",
+              "line": {
+                "color": "rgba(31,119,180,1)"
+              }
+            },
+            "text": "10,668",
+            "textposition": "inside",
+            "textfont": {
+              "color": "#FFF"
+            },
+            "hoverinfo": "text",
+            "name": "Total places created between 2009/10 and 2018/19",
+            "type": "bar",
+            "error_y": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "error_x": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "x": "Hertfordshire",
+            "y": 2679,
+            "marker": {
+              "color": "#F46A25",
+              "line": {
+                "color": "rgba(255,127,14,1)"
+              }
+            },
+            "text": "2,679",
+            "textposition": "inside",
+            "textfont": {
+              "color": "#FFF"
+            },
+            "hoverinfo": "text",
+            "name": "New places planned for delivery between 2018/19 and 2021/22",
+            "type": "bar",
+            "error_y": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "error_x": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "x": "Hertfordshire",
+            "y": 1090,
+            "marker": {
+              "color": "#801650",
+              "line": {
+                "color": "rgba(44,160,44,1)"
+              }
+            },
+            "text": "1,090",
+            "textposition": "inside",
+            "textfont": {
+              "color": "#FFF"
+            },
+            "hoverinfo": "text",
+            "name": "Estimated additional places still needed to meet demand in 2021/22",
+            "type": "bar",
+            "error_y": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "error_x": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          }
+        ],
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
+      },
+      "evals": [
+
+      ],
+      "jsHooks": [
+
+      ],
+      "deps": [
+        {
+          "name": "setprototypeof",
+          "version": "0.1",
+          "src": {
+            "href": "setprototypeof-0.1"
+          },
+          "meta": null,
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "crosstalk",
+          "version": "1.1.1",
+          "src": {
+            "href": "crosstalk-1.1.1"
+          },
+          "meta": null,
+          "script": "js/crosstalk.min.js",
+          "stylesheet": "css/crosstalk.css",
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "plotly-htmlwidgets-css",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-htmlwidgets-css-1.57.1"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "plotly-main",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-main-1.57.1"
+          },
+          "meta": null,
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        }
+      ]
+    },
+    "pupil_growth": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>19%<\/h3>\n    <p>Growth in secondary pupil numbers 2009/10 to 2021/22<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "total_funding_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>£284m<\/h3>\n    <p>Total primary and secondary basic need funding 2011 to 2022<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/005.json
+++ b/tests/shinytest/UI_tests-current/005.json
@@ -1,0 +1,287 @@
+{
+  "input": {
+    "LA_choice": "Hertfordshire",
+    "navbar": "la_scorecards",
+    "phase_choice": "Secondary",
+    "tabs": "forecast"
+  },
+  "output": {
+    "data_description": "Data for secondary state funded school places in Hertfordshire: ",
+    "estimated_additional_places": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>1,090<\/h3>\n    <p>Estimated additional secondary places needed to meet demand in 2021/22<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "estimated_spare_places": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>12%<\/h3>\n    <p>Estimated percentage of spare secondary places in 2021/22<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "label_estimate_y1": "<h1>One year ahead: 1%<\/h1> Overestimate of pupil numbers, within the middle 25-75% of local authorities' forecast accuracy scores",
+    "label_estimate_y3": "<h1>Three years ahead: 3.1%<\/h1> Overestimate of pupil numbers, within the middle 25-75% of local authorities' forecast accuracy scores",
+    "places_chart": {
+      "x": {
+        "layout": {
+          "margin": {
+            "b": 40,
+            "l": 60,
+            "t": 25,
+            "r": 10
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "title": ""
+          },
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "title": "",
+            "type": "category",
+            "categoryorder": "array",
+            "categoryarray": "Hertfordshire"
+          },
+          "barmode": "stack",
+          "uniformtext": {
+            "minsize": 12,
+            "mode": "hide"
+          },
+          "legend": {
+            "orientation": "h"
+          },
+          "font": {
+            "family": "Arial",
+            "size": 14
+          },
+          "title": {
+            "text": "Chart showing total places created, new places planned for delivery and estimated additional places needed to meet demand, by Local Authority compared to England",
+            "font": {
+              "color": "#ffffff"
+            }
+          },
+          "hovermode": "closest",
+          "showlegend": true
+        },
+        "source": "A",
+        "config": {
+          "showSendToCloud": false,
+          "displayModeBar": false
+        },
+        "data": [
+          {
+            "x": "Hertfordshire",
+            "y": 10668,
+            "marker": {
+              "color": "#12436D",
+              "line": {
+                "color": "rgba(31,119,180,1)"
+              }
+            },
+            "text": "10,668",
+            "textposition": "inside",
+            "textfont": {
+              "color": "#FFF"
+            },
+            "hoverinfo": "text",
+            "name": "Total places created between 2009/10 and 2018/19",
+            "type": "bar",
+            "error_y": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "error_x": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "x": "Hertfordshire",
+            "y": 2679,
+            "marker": {
+              "color": "#F46A25",
+              "line": {
+                "color": "rgba(255,127,14,1)"
+              }
+            },
+            "text": "2,679",
+            "textposition": "inside",
+            "textfont": {
+              "color": "#FFF"
+            },
+            "hoverinfo": "text",
+            "name": "New places planned for delivery between 2018/19 and 2021/22",
+            "type": "bar",
+            "error_y": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "error_x": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "x": "Hertfordshire",
+            "y": 1090,
+            "marker": {
+              "color": "#801650",
+              "line": {
+                "color": "rgba(44,160,44,1)"
+              }
+            },
+            "text": "1,090",
+            "textposition": "inside",
+            "textfont": {
+              "color": "#FFF"
+            },
+            "hoverinfo": "text",
+            "name": "Estimated additional places still needed to meet demand in 2021/22",
+            "type": "bar",
+            "error_y": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "error_x": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          }
+        ],
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
+      },
+      "evals": [
+
+      ],
+      "jsHooks": [
+
+      ],
+      "deps": [
+        {
+          "name": "setprototypeof",
+          "version": "0.1",
+          "src": {
+            "href": "setprototypeof-0.1"
+          },
+          "meta": null,
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "crosstalk",
+          "version": "1.1.1",
+          "src": {
+            "href": "crosstalk-1.1.1"
+          },
+          "meta": null,
+          "script": "js/crosstalk.min.js",
+          "stylesheet": "css/crosstalk.css",
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "plotly-htmlwidgets-css",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-htmlwidgets-css-1.57.1"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "plotly-main",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-main-1.57.1"
+          },
+          "meta": null,
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        }
+      ]
+    },
+    "pupil_growth": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>19%<\/h3>\n    <p>Growth in secondary pupil numbers 2009/10 to 2021/22<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "total_funding_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>£284m<\/h3>\n    <p>Total primary and secondary basic need funding 2011 to 2022<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/006.json
+++ b/tests/shinytest/UI_tests-current/006.json
@@ -1,0 +1,785 @@
+{
+  "input": {
+    "LA_choice": "Hertfordshire",
+    "navbar": "la_scorecards",
+    "phase_choice": "Secondary",
+    "tabs": "preference"
+  },
+  "output": {
+    "preference_p": {
+      "x": {
+        "data": [
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0,
+            "x": 0.746,
+            "y": 1,
+            "text": "First :  74.6 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(18,67,109,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "First",
+            "legendgroup": "First",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0,
+            "x": 0.809,
+            "y": 1,
+            "text": "First :  80.9 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(18,67,109,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "First",
+            "legendgroup": "First",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0.746,
+            "x": 0.11,
+            "y": 1,
+            "text": "Second :  11 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(244,119,56,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Second",
+            "legendgroup": "Second",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0.809,
+            "x": 0.09,
+            "y": 1,
+            "text": "Second :  9 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(244,119,56,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Second",
+            "legendgroup": "Second",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0.856,
+            "x": 0.0449999999999999,
+            "y": 1,
+            "text": "Third :  4.5 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(128,22,80,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Third",
+            "legendgroup": "Third",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0.899,
+            "x": 0.032,
+            "y": 1,
+            "text": "Third :  3.2 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(128,22,80,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Third",
+            "legendgroup": "Third",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0.901,
+            "x": 0.0990000000000001,
+            "y": 1,
+            "text": "Other :  9.9 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(40,161,151,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Other",
+            "legendgroup": "Other",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0.931,
+            "x": 0.069,
+            "y": 1,
+            "text": "Other :  6.9 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(40,161,151,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Other",
+            "legendgroup": "Other",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.373,
+            "y": 1,
+            "text": "74.6%",
+            "hovertext": "First :  74.6 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "First",
+            "legendgroup": "First",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.4045,
+            "y": 1,
+            "text": "80.9%",
+            "hovertext": "First :  80.9 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "First",
+            "legendgroup": "First",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.801,
+            "y": 1,
+            "text": "11%",
+            "hovertext": "Second :  11 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Second",
+            "legendgroup": "Second",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.854,
+            "y": 1,
+            "text": "9%",
+            "hovertext": "Second :  9 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Second",
+            "legendgroup": "Second",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.8785,
+            "y": 1,
+            "text": "4.5%",
+            "hovertext": "Third :  4.5 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Third",
+            "legendgroup": "Third",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.915,
+            "y": 1,
+            "text": "3.2%",
+            "hovertext": "Third :  3.2 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Third",
+            "legendgroup": "Third",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.9505,
+            "y": 1,
+            "text": "9.9%",
+            "hovertext": "Other :  9.9 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Other",
+            "legendgroup": "Other",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.9655,
+            "y": 1,
+            "text": "6.9%",
+            "hovertext": "Other :  6.9 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Other",
+            "legendgroup": "Other",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          }
+        ],
+        "layout": {
+          "margin": {
+            "t": 52.3082883630829,
+            "r": 7.30593607305936,
+            "b": 28.2717586827176,
+            "l": 10.958904109589
+          },
+          "font": {
+            "color": "rgba(0,0,0,1)",
+            "family": "Arial",
+            "size": 18.5969281859693
+          },
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              -0.05,
+              1.05
+            ],
+            "tickmode": "array",
+            "ticktext": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "tickvals": [
+              0,
+              0.25,
+              0.5,
+              0.75,
+              1
+            ],
+            "categoryorder": "array",
+            "categoryarray": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "y2",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "yaxis": {
+            "domain": [
+              0.552926525529265,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              0.4,
+              1.6
+            ],
+            "tickmode": "array",
+            "ticktext": "",
+            "tickvals": 1,
+            "categoryorder": "array",
+            "categoryarray": "",
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "x",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "shapes": [
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0.552926525529265,
+              "y1": 1
+            },
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 38.2565379825654,
+              "yanchor": 1,
+              "ysizemode": "pixel"
+            },
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 0.447073474470735
+            },
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 38.2565379825654,
+              "yanchor": 0.447073474470735,
+              "ysizemode": "pixel"
+            }
+          ],
+          "annotations": [
+            {
+              "text": "Hertfordshire",
+              "x": 0.5,
+              "y": 1,
+              "showarrow": false,
+              "ax": 0,
+              "ay": 0,
+              "font": {
+                "color": "rgba(26,26,26,1)",
+                "family": "Arial",
+                "size": 26.5670402656704
+              },
+              "xref": "paper",
+              "yref": "paper",
+              "textangle": 0,
+              "xanchor": "center",
+              "yanchor": "bottom"
+            },
+            {
+              "text": "England",
+              "x": 0.5,
+              "y": 0.447073474470735,
+              "showarrow": false,
+              "ax": 0,
+              "ay": 0,
+              "font": {
+                "color": "rgba(26,26,26,1)",
+                "family": "Arial",
+                "size": 26.5670402656704
+              },
+              "xref": "paper",
+              "yref": "paper",
+              "textangle": 0,
+              "xanchor": "center",
+              "yanchor": "bottom"
+            }
+          ],
+          "yaxis2": {
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              0.4,
+              1.6
+            ],
+            "tickmode": "array",
+            "ticktext": "",
+            "tickvals": 1,
+            "categoryorder": "array",
+            "categoryarray": "",
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "domain": [
+              0,
+              0.447073474470735
+            ],
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "x",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "showlegend": true,
+          "legend": {
+            "bgcolor": null,
+            "bordercolor": null,
+            "borderwidth": 0,
+            "font": {
+              "color": "rgba(0,0,0,1)",
+              "family": "Arial",
+              "size": 14
+            },
+            "y": -0.1,
+            "orientation": "h",
+            "x": 0.33
+          },
+          "hovermode": "closest",
+          "barmode": "relative",
+          "uniformtext": {
+            "minsize": 12,
+            "mode": "hide"
+          },
+          "title": {
+            "text": "Chart showing percentage of pupils recieving an offer from their first, second, third or other place schools, by Local Authority compared to England",
+            "font": {
+              "color": "#ffffff"
+            }
+          }
+        },
+        "config": {
+          "doubleClick": "reset",
+          "showSendToCloud": false,
+          "displayModeBar": false
+        },
+        "source": "A",
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
+      },
+      "evals": [
+
+      ],
+      "jsHooks": [
+
+      ],
+      "deps": [
+        {
+          "name": "setprototypeof",
+          "version": "0.1",
+          "src": {
+            "href": "setprototypeof-0.1"
+          },
+          "meta": null,
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "crosstalk",
+          "version": "1.1.1",
+          "src": {
+            "href": "crosstalk-1.1.1"
+          },
+          "meta": null,
+          "script": "js/crosstalk.min.js",
+          "stylesheet": "css/crosstalk.css",
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "plotly-htmlwidgets-css",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-htmlwidgets-css-1.57.1"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "plotly-main",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-main-1.57.1"
+          },
+          "meta": null,
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        }
+      ]
+    },
+    "prefT3_ENG": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>93%<\/h3>\n    <p>Percentage of applicants who received an offer of one of their top three preferred secondary schools in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "PrefT3_LA": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>90.1%<\/h3>\n    <p>Percentage of applicants who received an offer of one of their top three preferred secondary schools in Hertfordshire<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/007.json
+++ b/tests/shinytest/UI_tests-current/007.json
@@ -1,0 +1,516 @@
+{
+  "input": {
+    "LA_choice": "England",
+    "navbar": "la_scorecards",
+    "phase_choice": "Secondary",
+    "tabs": "preference"
+  },
+  "output": {
+    "preference_p": {
+      "x": {
+        "data": [
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0,
+            "x": 0.809,
+            "y": 1,
+            "text": "First :  80.9 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(18,67,109,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "First",
+            "legendgroup": "First",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0.809,
+            "x": 0.09,
+            "y": 1,
+            "text": "Second :  9 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(244,119,56,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Second",
+            "legendgroup": "Second",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0.899,
+            "x": 0.032,
+            "y": 1,
+            "text": "Third :  3.2 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(128,22,80,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Third",
+            "legendgroup": "Third",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0.931,
+            "x": 0.069,
+            "y": 1,
+            "text": "Other :  6.9 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(40,161,151,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Other",
+            "legendgroup": "Other",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.4045,
+            "y": 1,
+            "text": "80.9%",
+            "hovertext": "First :  80.9 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "First",
+            "legendgroup": "First",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.854,
+            "y": 1,
+            "text": "9%",
+            "hovertext": "Second :  9 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Second",
+            "legendgroup": "Second",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.915,
+            "y": 1,
+            "text": "3.2%",
+            "hovertext": "Third :  3.2 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Third",
+            "legendgroup": "Third",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.9655,
+            "y": 1,
+            "text": "6.9%",
+            "hovertext": "Other :  6.9 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Other",
+            "legendgroup": "Other",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          }
+        ],
+        "layout": {
+          "margin": {
+            "t": 52.3082883630829,
+            "r": 7.30593607305936,
+            "b": 28.2717586827176,
+            "l": 10.958904109589
+          },
+          "font": {
+            "color": "rgba(0,0,0,1)",
+            "family": "Arial",
+            "size": 18.5969281859693
+          },
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              -0.05,
+              1.05
+            ],
+            "tickmode": "array",
+            "ticktext": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "tickvals": [
+              0,
+              0.25,
+              0.5,
+              0.75,
+              1
+            ],
+            "categoryorder": "array",
+            "categoryarray": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "y",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              0.4,
+              1.6
+            ],
+            "tickmode": "array",
+            "ticktext": "",
+            "tickvals": 1,
+            "categoryorder": "array",
+            "categoryarray": "",
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "x",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "shapes": [
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 1
+            },
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 38.2565379825654,
+              "yanchor": 1,
+              "ysizemode": "pixel"
+            }
+          ],
+          "annotations": [
+            {
+              "text": "England",
+              "x": 0.5,
+              "y": 1,
+              "showarrow": false,
+              "ax": 0,
+              "ay": 0,
+              "font": {
+                "color": "rgba(26,26,26,1)",
+                "family": "Arial",
+                "size": 26.5670402656704
+              },
+              "xref": "paper",
+              "yref": "paper",
+              "textangle": 0,
+              "xanchor": "center",
+              "yanchor": "bottom"
+            }
+          ],
+          "showlegend": true,
+          "legend": {
+            "bgcolor": null,
+            "bordercolor": null,
+            "borderwidth": 0,
+            "font": {
+              "color": "rgba(0,0,0,1)",
+              "family": "Arial",
+              "size": 14
+            },
+            "y": -0.1,
+            "orientation": "h",
+            "x": 0.33
+          },
+          "hovermode": "closest",
+          "barmode": "relative",
+          "uniformtext": {
+            "minsize": 12,
+            "mode": "hide"
+          },
+          "title": {
+            "text": "Chart showing percentage of pupils recieving an offer from their first, second, third or other place schools, by Local Authority compared to England",
+            "font": {
+              "color": "#ffffff"
+            }
+          }
+        },
+        "config": {
+          "doubleClick": "reset",
+          "showSendToCloud": false,
+          "displayModeBar": false
+        },
+        "source": "A",
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
+      },
+      "evals": [
+
+      ],
+      "jsHooks": [
+
+      ],
+      "deps": [
+        {
+          "name": "setprototypeof",
+          "version": "0.1",
+          "src": {
+            "href": "setprototypeof-0.1"
+          },
+          "meta": null,
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "crosstalk",
+          "version": "1.1.1",
+          "src": {
+            "href": "crosstalk-1.1.1"
+          },
+          "meta": null,
+          "script": "js/crosstalk.min.js",
+          "stylesheet": "css/crosstalk.css",
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "plotly-htmlwidgets-css",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-htmlwidgets-css-1.57.1"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "plotly-main",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-main-1.57.1"
+          },
+          "meta": null,
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        }
+      ]
+    },
+    "prefT3_ENG": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>93%<\/h3>\n    <p>Percentage of applicants who received an offer of one of their top three preferred secondary schools in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "PrefT3_LA": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>93%<\/h3>\n    <p>Percentage of applicants who received an offer of one of their top three preferred secondary schools in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/008.json
+++ b/tests/shinytest/UI_tests-current/008.json
@@ -1,0 +1,516 @@
+{
+  "input": {
+    "LA_choice": "England",
+    "navbar": "la_scorecards",
+    "phase_choice": "Primary",
+    "tabs": "preference"
+  },
+  "output": {
+    "preference_p": {
+      "x": {
+        "data": [
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0,
+            "x": 0.906,
+            "y": 1,
+            "text": "First :  90.6 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(18,67,109,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "First",
+            "legendgroup": "First",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0.906,
+            "x": 0.054,
+            "y": 1,
+            "text": "Second :  5.4 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(244,119,56,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Second",
+            "legendgroup": "Second",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0.96,
+            "x": 0.015,
+            "y": 1,
+            "text": "Third :  1.5 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(128,22,80,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Third",
+            "legendgroup": "Third",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0.975,
+            "x": 0.025,
+            "y": 1,
+            "text": "Other :  2.5 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(40,161,151,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Other",
+            "legendgroup": "Other",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.453,
+            "y": 1,
+            "text": "90.6%",
+            "hovertext": "First :  90.6 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "First",
+            "legendgroup": "First",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.933,
+            "y": 1,
+            "text": "5.4%",
+            "hovertext": "Second :  5.4 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Second",
+            "legendgroup": "Second",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.9675,
+            "y": 1,
+            "text": null,
+            "hovertext": "Third :  1.5 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Third",
+            "legendgroup": "Third",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.9875,
+            "y": 1,
+            "text": null,
+            "hovertext": "Other :  2.5 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Other",
+            "legendgroup": "Other",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          }
+        ],
+        "layout": {
+          "margin": {
+            "t": 52.3082883630829,
+            "r": 7.30593607305936,
+            "b": 28.2717586827176,
+            "l": 10.958904109589
+          },
+          "font": {
+            "color": "rgba(0,0,0,1)",
+            "family": "Arial",
+            "size": 18.5969281859693
+          },
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              -0.05,
+              1.05
+            ],
+            "tickmode": "array",
+            "ticktext": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "tickvals": [
+              0,
+              0.25,
+              0.5,
+              0.75,
+              1
+            ],
+            "categoryorder": "array",
+            "categoryarray": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "y",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              0.4,
+              1.6
+            ],
+            "tickmode": "array",
+            "ticktext": "",
+            "tickvals": 1,
+            "categoryorder": "array",
+            "categoryarray": "",
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "x",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "shapes": [
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 1
+            },
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 38.2565379825654,
+              "yanchor": 1,
+              "ysizemode": "pixel"
+            }
+          ],
+          "annotations": [
+            {
+              "text": "England",
+              "x": 0.5,
+              "y": 1,
+              "showarrow": false,
+              "ax": 0,
+              "ay": 0,
+              "font": {
+                "color": "rgba(26,26,26,1)",
+                "family": "Arial",
+                "size": 26.5670402656704
+              },
+              "xref": "paper",
+              "yref": "paper",
+              "textangle": 0,
+              "xanchor": "center",
+              "yanchor": "bottom"
+            }
+          ],
+          "showlegend": true,
+          "legend": {
+            "bgcolor": null,
+            "bordercolor": null,
+            "borderwidth": 0,
+            "font": {
+              "color": "rgba(0,0,0,1)",
+              "family": "Arial",
+              "size": 14
+            },
+            "y": -0.1,
+            "orientation": "h",
+            "x": 0.33
+          },
+          "hovermode": "closest",
+          "barmode": "relative",
+          "uniformtext": {
+            "minsize": 12,
+            "mode": "hide"
+          },
+          "title": {
+            "text": "Chart showing percentage of pupils recieving an offer from their first, second, third or other place schools, by Local Authority compared to England",
+            "font": {
+              "color": "#ffffff"
+            }
+          }
+        },
+        "config": {
+          "doubleClick": "reset",
+          "showSendToCloud": false,
+          "displayModeBar": false
+        },
+        "source": "A",
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
+      },
+      "evals": [
+
+      ],
+      "jsHooks": [
+
+      ],
+      "deps": [
+        {
+          "name": "setprototypeof",
+          "version": "0.1",
+          "src": {
+            "href": "setprototypeof-0.1"
+          },
+          "meta": null,
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "crosstalk",
+          "version": "1.1.1",
+          "src": {
+            "href": "crosstalk-1.1.1"
+          },
+          "meta": null,
+          "script": "js/crosstalk.min.js",
+          "stylesheet": "css/crosstalk.css",
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "plotly-htmlwidgets-css",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-htmlwidgets-css-1.57.1"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "plotly-main",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-main-1.57.1"
+          },
+          "meta": null,
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        }
+      ]
+    },
+    "prefT3_ENG": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>97.5%<\/h3>\n    <p>Percentage of applicants who received an offer of one of their top three preferred primary schools in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "PrefT3_LA": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>93%<\/h3>\n    <p>Percentage of applicants who received an offer of one of their top three preferred secondary schools in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/009.json
+++ b/tests/shinytest/UI_tests-current/009.json
@@ -1,0 +1,516 @@
+{
+  "input": {
+    "LA_choice": "England",
+    "navbar": "la_scorecards",
+    "phase_choice": "Primary",
+    "tabs": "preference"
+  },
+  "output": {
+    "preference_p": {
+      "x": {
+        "data": [
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0,
+            "x": 0.906,
+            "y": 1,
+            "text": "First :  90.6 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(18,67,109,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "First",
+            "legendgroup": "First",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0.906,
+            "x": 0.054,
+            "y": 1,
+            "text": "Second :  5.4 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(244,119,56,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Second",
+            "legendgroup": "Second",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0.96,
+            "x": 0.015,
+            "y": 1,
+            "text": "Third :  1.5 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(128,22,80,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Third",
+            "legendgroup": "Third",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": 0.9,
+            "base": 0.975,
+            "x": 0.025,
+            "y": 1,
+            "text": "Other :  2.5 %",
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(40,161,151,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Other",
+            "legendgroup": "Other",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.453,
+            "y": 1,
+            "text": "90.6%",
+            "hovertext": "First :  90.6 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "First",
+            "legendgroup": "First",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.933,
+            "y": 1,
+            "text": "5.4%",
+            "hovertext": "Second :  5.4 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Second",
+            "legendgroup": "Second",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.9675,
+            "y": 1,
+            "text": null,
+            "hovertext": "Third :  1.5 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Third",
+            "legendgroup": "Third",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": 0.9875,
+            "y": 1,
+            "text": null,
+            "hovertext": "Other :  2.5 %",
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Other",
+            "legendgroup": "Other",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          }
+        ],
+        "layout": {
+          "margin": {
+            "t": 52.3082883630829,
+            "r": 7.30593607305936,
+            "b": 28.2717586827176,
+            "l": 10.958904109589
+          },
+          "font": {
+            "color": "rgba(0,0,0,1)",
+            "family": "Arial",
+            "size": 18.5969281859693
+          },
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              -0.05,
+              1.05
+            ],
+            "tickmode": "array",
+            "ticktext": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "tickvals": [
+              0,
+              0.25,
+              0.5,
+              0.75,
+              1
+            ],
+            "categoryorder": "array",
+            "categoryarray": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "y",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              0.4,
+              1.6
+            ],
+            "tickmode": "array",
+            "ticktext": "",
+            "tickvals": 1,
+            "categoryorder": "array",
+            "categoryarray": "",
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "x",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "shapes": [
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 1
+            },
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 38.2565379825654,
+              "yanchor": 1,
+              "ysizemode": "pixel"
+            }
+          ],
+          "annotations": [
+            {
+              "text": "England",
+              "x": 0.5,
+              "y": 1,
+              "showarrow": false,
+              "ax": 0,
+              "ay": 0,
+              "font": {
+                "color": "rgba(26,26,26,1)",
+                "family": "Arial",
+                "size": 26.5670402656704
+              },
+              "xref": "paper",
+              "yref": "paper",
+              "textangle": 0,
+              "xanchor": "center",
+              "yanchor": "bottom"
+            }
+          ],
+          "showlegend": true,
+          "legend": {
+            "bgcolor": null,
+            "bordercolor": null,
+            "borderwidth": 0,
+            "font": {
+              "color": "rgba(0,0,0,1)",
+              "family": "Arial",
+              "size": 14
+            },
+            "y": -0.1,
+            "orientation": "h",
+            "x": 0.33
+          },
+          "hovermode": "closest",
+          "barmode": "relative",
+          "uniformtext": {
+            "minsize": 12,
+            "mode": "hide"
+          },
+          "title": {
+            "text": "Chart showing percentage of pupils recieving an offer from their first, second, third or other place schools, by Local Authority compared to England",
+            "font": {
+              "color": "#ffffff"
+            }
+          }
+        },
+        "config": {
+          "doubleClick": "reset",
+          "showSendToCloud": false,
+          "displayModeBar": false
+        },
+        "source": "A",
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
+      },
+      "evals": [
+
+      ],
+      "jsHooks": [
+
+      ],
+      "deps": [
+        {
+          "name": "setprototypeof",
+          "version": "0.1",
+          "src": {
+            "href": "setprototypeof-0.1"
+          },
+          "meta": null,
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "crosstalk",
+          "version": "1.1.1",
+          "src": {
+            "href": "crosstalk-1.1.1"
+          },
+          "meta": null,
+          "script": "js/crosstalk.min.js",
+          "stylesheet": "css/crosstalk.css",
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "plotly-htmlwidgets-css",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-htmlwidgets-css-1.57.1"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "plotly-main",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-main-1.57.1"
+          },
+          "meta": null,
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        }
+      ]
+    },
+    "prefT3_ENG": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>97.5%<\/h3>\n    <p>Percentage of applicants who received an offer of one of their top three preferred primary schools in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "PrefT3_LA": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>93%<\/h3>\n    <p>Percentage of applicants who received an offer of one of their top three preferred secondary schools in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/010.json
+++ b/tests/shinytest/UI_tests-current/010.json
@@ -1,0 +1,624 @@
+{
+  "input": {
+    "LA_choice": "England",
+    "navbar": "la_scorecards",
+    "phase_choice": "Primary",
+    "tabs": "quality"
+  },
+  "output": {
+    "England_GO_places": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>91%<\/h3>\n    <p>Percentage of new places created in good and outstanding primary schools in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "no_rating_line": "New places with no rating = 9,555",
+    "quality_chart": {
+      "x": {
+        "data": [
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0,
+              0
+            ],
+            "x": [
+              0.196334068357222,
+              0.185146780403107
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Oustanding :  7123  places",
+              "Oustanding :  884730  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(18,67,109,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Oustanding",
+            "legendgroup": "Oustanding",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0.196334068357222,
+              0.185146780403107
+            ],
+            "x": [
+              0.713423373759647,
+              0.701731891356615
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Good :  25883  places",
+              "Good :  3353249  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(244,119,56,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Good",
+            "legendgroup": "Good",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0.909757442116869,
+              0.886878671759722
+            ],
+            "x": [
+              0.0816152149944873,
+              0.0993583177096401
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Requires Improvement :  2961  places",
+              "Requires Improvement :  474787  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(128,22,80,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Requires Improvement",
+            "legendgroup": "Requires Improvement",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0.991372657111356,
+              0.986236989469362
+            ],
+            "x": [
+              0.00862734288864386,
+              0.0137630105306378
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Inadequate :  313  places",
+              "Inadequate :  65767  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(40,161,151,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Inadequate",
+            "legendgroup": "Inadequate",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.0981670341786108,
+              0.0925733902015535
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "7,123",
+              "884,730"
+            ],
+            "hovertext": [
+              "Oustanding :  7123  places",
+              "Oustanding :  884730  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Oustanding",
+            "legendgroup": "Oustanding",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.553045755237045,
+              0.536012726081415
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "25,883",
+              "3,353,249"
+            ],
+            "hovertext": [
+              "Good :  25883  places",
+              "Good :  3353249  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Good",
+            "legendgroup": "Good",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.950565049614112,
+              0.936557830614542
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "2,961",
+              "474,787"
+            ],
+            "hovertext": [
+              "Requires Improvement :  2961  places",
+              "Requires Improvement :  474787  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Requires Improvement",
+            "legendgroup": "Requires Improvement",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.995686328555678,
+              0.993118494734681
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              null,
+              null
+            ],
+            "hovertext": [
+              "Inadequate :  313  places",
+              "Inadequate :  65767  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Inadequate",
+            "legendgroup": "Inadequate",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          }
+        ],
+        "layout": {
+          "margin": {
+            "t": 52.3082883630829,
+            "r": 7.30593607305936,
+            "b": 28.2717586827176,
+            "l": 70.4690743046907
+          },
+          "font": {
+            "color": "rgba(0,0,0,1)",
+            "family": "Arial",
+            "size": 18.5969281859693
+          },
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              -0.05,
+              1.05
+            ],
+            "tickmode": "array",
+            "ticktext": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "tickvals": [
+              0,
+              0.25,
+              0.5,
+              0.75,
+              1
+            ],
+            "categoryorder": "array",
+            "categoryarray": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "y",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              0.4,
+              2.6
+            ],
+            "tickmode": "array",
+            "ticktext": [
+              "Existing",
+              "New"
+            ],
+            "tickvals": [
+              1,
+              2
+            ],
+            "categoryorder": "array",
+            "categoryarray": [
+              "Existing",
+              "New"
+            ],
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "x",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "shapes": [
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 1
+            },
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 38.2565379825654,
+              "yanchor": 1,
+              "ysizemode": "pixel"
+            }
+          ],
+          "annotations": [
+            {
+              "text": "England",
+              "x": 0.5,
+              "y": 1,
+              "showarrow": false,
+              "ax": 0,
+              "ay": 0,
+              "font": {
+                "color": "rgba(26,26,26,1)",
+                "family": "Arial",
+                "size": 26.5670402656704
+              },
+              "xref": "paper",
+              "yref": "paper",
+              "textangle": 0,
+              "xanchor": "center",
+              "yanchor": "bottom"
+            }
+          ],
+          "showlegend": true,
+          "legend": {
+            "bgcolor": null,
+            "bordercolor": null,
+            "borderwidth": 0,
+            "font": {
+              "color": "rgba(0,0,0,1)",
+              "family": "Arial",
+              "size": 14
+            },
+            "y": -0.1,
+            "orientation": "h",
+            "x": 0.2
+          },
+          "hovermode": "closest",
+          "barmode": "relative",
+          "title": {
+            "text": "Chart showing the quality of new and existing school places and estimated additional places, by Local Authority compared to England",
+            "font": {
+              "color": "#ffffff"
+            }
+          }
+        },
+        "config": {
+          "doubleClick": "reset",
+          "showSendToCloud": false,
+          "displayModeBar": false
+        },
+        "source": "A",
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
+      },
+      "evals": [
+
+      ],
+      "jsHooks": [
+
+      ],
+      "deps": [
+        {
+          "name": "setprototypeof",
+          "version": "0.1",
+          "src": {
+            "href": "setprototypeof-0.1"
+          },
+          "meta": null,
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "crosstalk",
+          "version": "1.1.1",
+          "src": {
+            "href": "crosstalk-1.1.1"
+          },
+          "meta": null,
+          "script": "js/crosstalk.min.js",
+          "stylesheet": "css/crosstalk.css",
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "plotly-htmlwidgets-css",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-htmlwidgets-css-1.57.1"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "plotly-main",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-main-1.57.1"
+          },
+          "meta": null,
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        }
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/011.json
+++ b/tests/shinytest/UI_tests-current/011.json
@@ -1,0 +1,624 @@
+{
+  "input": {
+    "LA_choice": "England",
+    "navbar": "la_scorecards",
+    "phase_choice": "Secondary",
+    "tabs": "quality"
+  },
+  "output": {
+    "England_GO_places": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>88.2%<\/h3>\n    <p>Percentage of new places created in good and outstanding secondary schools in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "no_rating_line": "New places with no rating = 30,445",
+    "quality_chart": {
+      "x": {
+        "data": [
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0,
+              0
+            ],
+            "x": [
+              0.290886942641715,
+              0.238142405143364
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Oustanding :  13850  places",
+              "Oustanding :  837639  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(18,67,109,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Oustanding",
+            "legendgroup": "Oustanding",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0.290886942641715,
+              0.238142405143364
+            ],
+            "x": [
+              0.590910045575788,
+              0.558595912249633
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Good :  28135  places",
+              "Good :  1964798  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(244,119,56,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Good",
+            "legendgroup": "Good",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0.881796988217504,
+              0.796738317392997
+            ],
+            "x": [
+              0.096129208409468,
+              0.161065302168911
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Requires Improvement :  4577  places",
+              "Requires Improvement :  566529  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(128,22,80,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Requires Improvement",
+            "legendgroup": "Requires Improvement",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0.977926196626972,
+              0.957803619561908
+            ],
+            "x": [
+              0.0220738033730283,
+              0.0421963804380923
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Inadequate :  1051  places",
+              "Inadequate :  148421  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(40,161,151,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Inadequate",
+            "legendgroup": "Inadequate",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.145443471320858,
+              0.119071202571682
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "13,850",
+              "837,639"
+            ],
+            "hovertext": [
+              "Oustanding :  13850  places",
+              "Oustanding :  837639  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Oustanding",
+            "legendgroup": "Oustanding",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.58634196542961,
+              0.51744036126818
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "28,135",
+              "1,964,798"
+            ],
+            "hovertext": [
+              "Good :  28135  places",
+              "Good :  1964798  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Good",
+            "legendgroup": "Good",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.929861592422238,
+              0.877270968477452
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "4,577",
+              "566,529"
+            ],
+            "hovertext": [
+              "Requires Improvement :  4577  places",
+              "Requires Improvement :  566529  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Requires Improvement",
+            "legendgroup": "Requires Improvement",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.988963098313486,
+              0.978901809780954
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              null,
+              null
+            ],
+            "hovertext": [
+              "Inadequate :  1051  places",
+              "Inadequate :  148421  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Inadequate",
+            "legendgroup": "Inadequate",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          }
+        ],
+        "layout": {
+          "margin": {
+            "t": 52.3082883630829,
+            "r": 7.30593607305936,
+            "b": 28.2717586827176,
+            "l": 70.4690743046907
+          },
+          "font": {
+            "color": "rgba(0,0,0,1)",
+            "family": "Arial",
+            "size": 18.5969281859693
+          },
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              -0.05,
+              1.05
+            ],
+            "tickmode": "array",
+            "ticktext": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "tickvals": [
+              0,
+              0.25,
+              0.5,
+              0.75,
+              1
+            ],
+            "categoryorder": "array",
+            "categoryarray": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "y",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              0.4,
+              2.6
+            ],
+            "tickmode": "array",
+            "ticktext": [
+              "Existing",
+              "New"
+            ],
+            "tickvals": [
+              1,
+              2
+            ],
+            "categoryorder": "array",
+            "categoryarray": [
+              "Existing",
+              "New"
+            ],
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "x",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "shapes": [
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 1
+            },
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 38.2565379825654,
+              "yanchor": 1,
+              "ysizemode": "pixel"
+            }
+          ],
+          "annotations": [
+            {
+              "text": "England",
+              "x": 0.5,
+              "y": 1,
+              "showarrow": false,
+              "ax": 0,
+              "ay": 0,
+              "font": {
+                "color": "rgba(26,26,26,1)",
+                "family": "Arial",
+                "size": 26.5670402656704
+              },
+              "xref": "paper",
+              "yref": "paper",
+              "textangle": 0,
+              "xanchor": "center",
+              "yanchor": "bottom"
+            }
+          ],
+          "showlegend": true,
+          "legend": {
+            "bgcolor": null,
+            "bordercolor": null,
+            "borderwidth": 0,
+            "font": {
+              "color": "rgba(0,0,0,1)",
+              "family": "Arial",
+              "size": 14
+            },
+            "y": -0.1,
+            "orientation": "h",
+            "x": 0.2
+          },
+          "hovermode": "closest",
+          "barmode": "relative",
+          "title": {
+            "text": "Chart showing the quality of new and existing school places and estimated additional places, by Local Authority compared to England",
+            "font": {
+              "color": "#ffffff"
+            }
+          }
+        },
+        "config": {
+          "doubleClick": "reset",
+          "showSendToCloud": false,
+          "displayModeBar": false
+        },
+        "source": "A",
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
+      },
+      "evals": [
+
+      ],
+      "jsHooks": [
+
+      ],
+      "deps": [
+        {
+          "name": "setprototypeof",
+          "version": "0.1",
+          "src": {
+            "href": "setprototypeof-0.1"
+          },
+          "meta": null,
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "crosstalk",
+          "version": "1.1.1",
+          "src": {
+            "href": "crosstalk-1.1.1"
+          },
+          "meta": null,
+          "script": "js/crosstalk.min.js",
+          "stylesheet": "css/crosstalk.css",
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "plotly-htmlwidgets-css",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-htmlwidgets-css-1.57.1"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "plotly-main",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-main-1.57.1"
+          },
+          "meta": null,
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        }
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/012.json
+++ b/tests/shinytest/UI_tests-current/012.json
@@ -1,0 +1,624 @@
+{
+  "input": {
+    "LA_choice": "England",
+    "navbar": "la_scorecards",
+    "phase_choice": "Primary",
+    "tabs": "quality"
+  },
+  "output": {
+    "England_GO_places": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>91%<\/h3>\n    <p>Percentage of new places created in good and outstanding primary schools in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "no_rating_line": "New places with no rating = 9,555",
+    "quality_chart": {
+      "x": {
+        "data": [
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0,
+              0
+            ],
+            "x": [
+              0.196334068357222,
+              0.185146780403107
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Oustanding :  7123  places",
+              "Oustanding :  884730  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(18,67,109,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Oustanding",
+            "legendgroup": "Oustanding",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0.196334068357222,
+              0.185146780403107
+            ],
+            "x": [
+              0.713423373759647,
+              0.701731891356615
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Good :  25883  places",
+              "Good :  3353249  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(244,119,56,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Good",
+            "legendgroup": "Good",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0.909757442116869,
+              0.886878671759722
+            ],
+            "x": [
+              0.0816152149944873,
+              0.0993583177096401
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Requires Improvement :  2961  places",
+              "Requires Improvement :  474787  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(128,22,80,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Requires Improvement",
+            "legendgroup": "Requires Improvement",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0.991372657111356,
+              0.986236989469362
+            ],
+            "x": [
+              0.00862734288864386,
+              0.0137630105306378
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Inadequate :  313  places",
+              "Inadequate :  65767  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(40,161,151,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Inadequate",
+            "legendgroup": "Inadequate",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.0981670341786108,
+              0.0925733902015535
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "7,123",
+              "884,730"
+            ],
+            "hovertext": [
+              "Oustanding :  7123  places",
+              "Oustanding :  884730  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Oustanding",
+            "legendgroup": "Oustanding",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.553045755237045,
+              0.536012726081415
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "25,883",
+              "3,353,249"
+            ],
+            "hovertext": [
+              "Good :  25883  places",
+              "Good :  3353249  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Good",
+            "legendgroup": "Good",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.950565049614112,
+              0.936557830614542
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "2,961",
+              "474,787"
+            ],
+            "hovertext": [
+              "Requires Improvement :  2961  places",
+              "Requires Improvement :  474787  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Requires Improvement",
+            "legendgroup": "Requires Improvement",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.995686328555678,
+              0.993118494734681
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              null,
+              null
+            ],
+            "hovertext": [
+              "Inadequate :  313  places",
+              "Inadequate :  65767  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Inadequate",
+            "legendgroup": "Inadequate",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          }
+        ],
+        "layout": {
+          "margin": {
+            "t": 52.3082883630829,
+            "r": 7.30593607305936,
+            "b": 28.2717586827176,
+            "l": 70.4690743046907
+          },
+          "font": {
+            "color": "rgba(0,0,0,1)",
+            "family": "Arial",
+            "size": 18.5969281859693
+          },
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              -0.05,
+              1.05
+            ],
+            "tickmode": "array",
+            "ticktext": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "tickvals": [
+              0,
+              0.25,
+              0.5,
+              0.75,
+              1
+            ],
+            "categoryorder": "array",
+            "categoryarray": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "y",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              0.4,
+              2.6
+            ],
+            "tickmode": "array",
+            "ticktext": [
+              "Existing",
+              "New"
+            ],
+            "tickvals": [
+              1,
+              2
+            ],
+            "categoryorder": "array",
+            "categoryarray": [
+              "Existing",
+              "New"
+            ],
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "x",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "shapes": [
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 1
+            },
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 38.2565379825654,
+              "yanchor": 1,
+              "ysizemode": "pixel"
+            }
+          ],
+          "annotations": [
+            {
+              "text": "England",
+              "x": 0.5,
+              "y": 1,
+              "showarrow": false,
+              "ax": 0,
+              "ay": 0,
+              "font": {
+                "color": "rgba(26,26,26,1)",
+                "family": "Arial",
+                "size": 26.5670402656704
+              },
+              "xref": "paper",
+              "yref": "paper",
+              "textangle": 0,
+              "xanchor": "center",
+              "yanchor": "bottom"
+            }
+          ],
+          "showlegend": true,
+          "legend": {
+            "bgcolor": null,
+            "bordercolor": null,
+            "borderwidth": 0,
+            "font": {
+              "color": "rgba(0,0,0,1)",
+              "family": "Arial",
+              "size": 14
+            },
+            "y": -0.1,
+            "orientation": "h",
+            "x": 0.2
+          },
+          "hovermode": "closest",
+          "barmode": "relative",
+          "title": {
+            "text": "Chart showing the quality of new and existing school places and estimated additional places, by Local Authority compared to England",
+            "font": {
+              "color": "#ffffff"
+            }
+          }
+        },
+        "config": {
+          "doubleClick": "reset",
+          "showSendToCloud": false,
+          "displayModeBar": false
+        },
+        "source": "A",
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
+      },
+      "evals": [
+
+      ],
+      "jsHooks": [
+
+      ],
+      "deps": [
+        {
+          "name": "setprototypeof",
+          "version": "0.1",
+          "src": {
+            "href": "setprototypeof-0.1"
+          },
+          "meta": null,
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "crosstalk",
+          "version": "1.1.1",
+          "src": {
+            "href": "crosstalk-1.1.1"
+          },
+          "meta": null,
+          "script": "js/crosstalk.min.js",
+          "stylesheet": "css/crosstalk.css",
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "plotly-htmlwidgets-css",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-htmlwidgets-css-1.57.1"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "plotly-main",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-main-1.57.1"
+          },
+          "meta": null,
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        }
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/013.json
+++ b/tests/shinytest/UI_tests-current/013.json
@@ -1,0 +1,624 @@
+{
+  "input": {
+    "LA_choice": "England",
+    "navbar": "la_scorecards",
+    "phase_choice": "Primary",
+    "tabs": "quality"
+  },
+  "output": {
+    "England_GO_places": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>91%<\/h3>\n    <p>Percentage of new places created in good and outstanding primary schools in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "no_rating_line": "New places with no rating = 9,555",
+    "quality_chart": {
+      "x": {
+        "data": [
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0,
+              0
+            ],
+            "x": [
+              0.196334068357222,
+              0.185146780403107
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Oustanding :  7123  places",
+              "Oustanding :  884730  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(18,67,109,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Oustanding",
+            "legendgroup": "Oustanding",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0.196334068357222,
+              0.185146780403107
+            ],
+            "x": [
+              0.713423373759647,
+              0.701731891356615
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Good :  25883  places",
+              "Good :  3353249  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(244,119,56,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Good",
+            "legendgroup": "Good",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0.909757442116869,
+              0.886878671759722
+            ],
+            "x": [
+              0.0816152149944873,
+              0.0993583177096401
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Requires Improvement :  2961  places",
+              "Requires Improvement :  474787  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(128,22,80,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Requires Improvement",
+            "legendgroup": "Requires Improvement",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0.991372657111356,
+              0.986236989469362
+            ],
+            "x": [
+              0.00862734288864386,
+              0.0137630105306378
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Inadequate :  313  places",
+              "Inadequate :  65767  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(40,161,151,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Inadequate",
+            "legendgroup": "Inadequate",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.0981670341786108,
+              0.0925733902015535
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "7,123",
+              "884,730"
+            ],
+            "hovertext": [
+              "Oustanding :  7123  places",
+              "Oustanding :  884730  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Oustanding",
+            "legendgroup": "Oustanding",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.553045755237045,
+              0.536012726081415
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "25,883",
+              "3,353,249"
+            ],
+            "hovertext": [
+              "Good :  25883  places",
+              "Good :  3353249  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Good",
+            "legendgroup": "Good",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.950565049614112,
+              0.936557830614542
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "2,961",
+              "474,787"
+            ],
+            "hovertext": [
+              "Requires Improvement :  2961  places",
+              "Requires Improvement :  474787  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Requires Improvement",
+            "legendgroup": "Requires Improvement",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.995686328555678,
+              0.993118494734681
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              null,
+              null
+            ],
+            "hovertext": [
+              "Inadequate :  313  places",
+              "Inadequate :  65767  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Inadequate",
+            "legendgroup": "Inadequate",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          }
+        ],
+        "layout": {
+          "margin": {
+            "t": 52.3082883630829,
+            "r": 7.30593607305936,
+            "b": 28.2717586827176,
+            "l": 70.4690743046907
+          },
+          "font": {
+            "color": "rgba(0,0,0,1)",
+            "family": "Arial",
+            "size": 18.5969281859693
+          },
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              -0.05,
+              1.05
+            ],
+            "tickmode": "array",
+            "ticktext": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "tickvals": [
+              0,
+              0.25,
+              0.5,
+              0.75,
+              1
+            ],
+            "categoryorder": "array",
+            "categoryarray": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "y",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              0.4,
+              2.6
+            ],
+            "tickmode": "array",
+            "ticktext": [
+              "Existing",
+              "New"
+            ],
+            "tickvals": [
+              1,
+              2
+            ],
+            "categoryorder": "array",
+            "categoryarray": [
+              "Existing",
+              "New"
+            ],
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "x",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "shapes": [
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 1
+            },
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 38.2565379825654,
+              "yanchor": 1,
+              "ysizemode": "pixel"
+            }
+          ],
+          "annotations": [
+            {
+              "text": "England",
+              "x": 0.5,
+              "y": 1,
+              "showarrow": false,
+              "ax": 0,
+              "ay": 0,
+              "font": {
+                "color": "rgba(26,26,26,1)",
+                "family": "Arial",
+                "size": 26.5670402656704
+              },
+              "xref": "paper",
+              "yref": "paper",
+              "textangle": 0,
+              "xanchor": "center",
+              "yanchor": "bottom"
+            }
+          ],
+          "showlegend": true,
+          "legend": {
+            "bgcolor": null,
+            "bordercolor": null,
+            "borderwidth": 0,
+            "font": {
+              "color": "rgba(0,0,0,1)",
+              "family": "Arial",
+              "size": 14
+            },
+            "y": -0.1,
+            "orientation": "h",
+            "x": 0.2
+          },
+          "hovermode": "closest",
+          "barmode": "relative",
+          "title": {
+            "text": "Chart showing the quality of new and existing school places and estimated additional places, by Local Authority compared to England",
+            "font": {
+              "color": "#ffffff"
+            }
+          }
+        },
+        "config": {
+          "doubleClick": "reset",
+          "showSendToCloud": false,
+          "displayModeBar": false
+        },
+        "source": "A",
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
+      },
+      "evals": [
+
+      ],
+      "jsHooks": [
+
+      ],
+      "deps": [
+        {
+          "name": "setprototypeof",
+          "version": "0.1",
+          "src": {
+            "href": "setprototypeof-0.1"
+          },
+          "meta": null,
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "crosstalk",
+          "version": "1.1.1",
+          "src": {
+            "href": "crosstalk-1.1.1"
+          },
+          "meta": null,
+          "script": "js/crosstalk.min.js",
+          "stylesheet": "css/crosstalk.css",
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "plotly-htmlwidgets-css",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-htmlwidgets-css-1.57.1"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "plotly-main",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-main-1.57.1"
+          },
+          "meta": null,
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        }
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/014.json
+++ b/tests/shinytest/UI_tests-current/014.json
@@ -1,0 +1,1016 @@
+{
+  "input": {
+    "LA_choice": "Cheshire East",
+    "navbar": "la_scorecards",
+    "phase_choice": "Primary",
+    "tabs": "quality"
+  },
+  "output": {
+    "LA_GO_places": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>100%<\/h3>\n    <p>Percentage of new places created in good and outstanding primary schools in Cheshire East<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "LA_GO_ran": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>1<\/h3>\n    <p>LA Rank out of 120 LAs that created new places between 2017/18 and 2018/19 (ranks can be tied)<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "no_rating_line": "New places with no rating = NA",
+    "quality_chart": {
+      "x": {
+        "data": [
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0,
+              0
+            ],
+            "x": [
+              0,
+              0.243026366068017
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Oustanding :  NA  places",
+              "Oustanding :  7632  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(18,67,109,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Oustanding",
+            "legendgroup": "Oustanding",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0,
+              0
+            ],
+            "x": [
+              0.196334068357222,
+              0.185146780403107
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Oustanding :  7123  places",
+              "Oustanding :  884730  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(18,67,109,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Oustanding",
+            "legendgroup": "Oustanding",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0,
+              0.243026366068017
+            ],
+            "x": [
+              1,
+              0.63288116163546
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Good :  449  places",
+              "Good :  19875  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(244,119,56,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Good",
+            "legendgroup": "Good",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0.196334068357222,
+              0.185146780403107
+            ],
+            "x": [
+              0.713423373759647,
+              0.701731891356615
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Good :  25883  places",
+              "Good :  3353249  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(244,119,56,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Good",
+            "legendgroup": "Good",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              1,
+              0.875907527703477
+            ],
+            "x": [
+              0,
+              0.0973442873519297
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Requires Improvement :  NA  places",
+              "Requires Improvement :  3057  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(128,22,80,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Requires Improvement",
+            "legendgroup": "Requires Improvement",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0.909757442116869,
+              0.886878671759722
+            ],
+            "x": [
+              0.0816152149944873,
+              0.0993583177096401
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Requires Improvement :  2961  places",
+              "Requires Improvement :  474787  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(128,22,80,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Requires Improvement",
+            "legendgroup": "Requires Improvement",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              1,
+              0.973251815055407
+            ],
+            "x": [
+              0,
+              0.0267481849445931
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Inadequate :  NA  places",
+              "Inadequate :  840  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(40,161,151,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Inadequate",
+            "legendgroup": "Inadequate",
+            "showlegend": true,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "orientation": "h",
+            "width": [
+              0.9,
+              0.9
+            ],
+            "base": [
+              0.991372657111356,
+              0.986236989469362
+            ],
+            "x": [
+              0.00862734288864386,
+              0.0137630105306378
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "Inadequate :  313  places",
+              "Inadequate :  65767  places"
+            ],
+            "type": "bar",
+            "marker": {
+              "autocolorscale": false,
+              "color": "rgba(40,161,151,1)",
+              "line": {
+                "width": 1.88976377952756,
+                "color": "transparent"
+              }
+            },
+            "name": "Inadequate",
+            "legendgroup": "Inadequate",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0,
+              0.121513183034008
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              null,
+              "7,632"
+            ],
+            "hovertext": [
+              "Oustanding :  NA  places",
+              "Oustanding :  7632  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Oustanding",
+            "legendgroup": "Oustanding",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.0981670341786108,
+              0.0925733902015535
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "7,123",
+              "884,730"
+            ],
+            "hovertext": [
+              "Oustanding :  7123  places",
+              "Oustanding :  884730  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Oustanding",
+            "legendgroup": "Oustanding",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.5,
+              0.559466946885747
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "449",
+              "19,875"
+            ],
+            "hovertext": [
+              "Good :  449  places",
+              "Good :  19875  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Good",
+            "legendgroup": "Good",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.553045755237045,
+              0.536012726081415
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "25,883",
+              "3,353,249"
+            ],
+            "hovertext": [
+              "Good :  25883  places",
+              "Good :  3353249  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Good",
+            "legendgroup": "Good",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              1,
+              0.924579671379442
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              null,
+              "3,057"
+            ],
+            "hovertext": [
+              "Requires Improvement :  NA  places",
+              "Requires Improvement :  3057  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Requires Improvement",
+            "legendgroup": "Requires Improvement",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.950565049614112,
+              0.936557830614542
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              "2,961",
+              "474,787"
+            ],
+            "hovertext": [
+              "Requires Improvement :  2961  places",
+              "Requires Improvement :  474787  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Requires Improvement",
+            "legendgroup": "Requires Improvement",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              1,
+              0.986625907527704
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              null,
+              null
+            ],
+            "hovertext": [
+              "Inadequate :  NA  places",
+              "Inadequate :  840  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Inadequate",
+            "legendgroup": "Inadequate",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y",
+            "hoverinfo": "text",
+            "frame": null
+          },
+          {
+            "x": [
+              0.995686328555678,
+              0.993118494734681
+            ],
+            "y": [
+              2,
+              1
+            ],
+            "text": [
+              null,
+              null
+            ],
+            "hovertext": [
+              "Inadequate :  313  places",
+              "Inadequate :  65767  places"
+            ],
+            "textfont": {
+              "size": 15.1181102362205,
+              "color": "rgba(255,255,255,1)"
+            },
+            "type": "scatter",
+            "mode": "text",
+            "hoveron": "points",
+            "name": "Inadequate",
+            "legendgroup": "Inadequate",
+            "showlegend": false,
+            "xaxis": "x",
+            "yaxis": "y2",
+            "hoverinfo": "text",
+            "frame": null
+          }
+        ],
+        "layout": {
+          "margin": {
+            "t": 52.3082883630829,
+            "r": 7.30593607305936,
+            "b": 28.2717586827176,
+            "l": 70.4690743046907
+          },
+          "font": {
+            "color": "rgba(0,0,0,1)",
+            "family": "Arial",
+            "size": 18.5969281859693
+          },
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              -0.05,
+              1.05
+            ],
+            "tickmode": "array",
+            "ticktext": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "tickvals": [
+              0,
+              0.25,
+              0.5,
+              0.75,
+              1
+            ],
+            "categoryorder": "array",
+            "categoryarray": [
+              "0%",
+              "25%",
+              "50%",
+              "75%",
+              "100%"
+            ],
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "y2",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "yaxis": {
+            "domain": [
+              0.552926525529265,
+              1
+            ],
+            "automargin": true,
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              0.4,
+              2.6
+            ],
+            "tickmode": "array",
+            "ticktext": [
+              "Existing",
+              "New"
+            ],
+            "tickvals": [
+              1,
+              2
+            ],
+            "categoryorder": "array",
+            "categoryarray": [
+              "Existing",
+              "New"
+            ],
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "x",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "shapes": [
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0.552926525529265,
+              "y1": 1
+            },
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 38.2565379825654,
+              "yanchor": 1,
+              "ysizemode": "pixel"
+            },
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 0.447073474470735
+            },
+            {
+              "type": "rect",
+              "fillcolor": null,
+              "line": {
+                "color": null,
+                "width": 0,
+                "linetype": [
+
+                ]
+              },
+              "yref": "paper",
+              "xref": "paper",
+              "x0": 0,
+              "x1": 1,
+              "y0": 0,
+              "y1": 38.2565379825654,
+              "yanchor": 0.447073474470735,
+              "ysizemode": "pixel"
+            }
+          ],
+          "annotations": [
+            {
+              "text": "Cheshire East",
+              "x": 0.5,
+              "y": 1,
+              "showarrow": false,
+              "ax": 0,
+              "ay": 0,
+              "font": {
+                "color": "rgba(26,26,26,1)",
+                "family": "Arial",
+                "size": 26.5670402656704
+              },
+              "xref": "paper",
+              "yref": "paper",
+              "textangle": 0,
+              "xanchor": "center",
+              "yanchor": "bottom"
+            },
+            {
+              "text": "England",
+              "x": 0.5,
+              "y": 0.447073474470735,
+              "showarrow": false,
+              "ax": 0,
+              "ay": 0,
+              "font": {
+                "color": "rgba(26,26,26,1)",
+                "family": "Arial",
+                "size": 26.5670402656704
+              },
+              "xref": "paper",
+              "yref": "paper",
+              "textangle": 0,
+              "xanchor": "center",
+              "yanchor": "bottom"
+            }
+          ],
+          "yaxis2": {
+            "type": "linear",
+            "autorange": false,
+            "range": [
+              0.4,
+              2.6
+            ],
+            "tickmode": "array",
+            "ticktext": [
+              "Existing",
+              "New"
+            ],
+            "tickvals": [
+              1,
+              2
+            ],
+            "categoryorder": "array",
+            "categoryarray": [
+              "Existing",
+              "New"
+            ],
+            "nticks": null,
+            "ticks": "",
+            "tickcolor": null,
+            "ticklen": 3.65296803652968,
+            "tickwidth": 0,
+            "showticklabels": true,
+            "tickfont": {
+              "color": "rgba(77,77,77,1)",
+              "family": "Arial",
+              "size": 14.8775425487754
+            },
+            "tickangle": 0,
+            "showline": false,
+            "linecolor": null,
+            "linewidth": 0,
+            "showgrid": true,
+            "domain": [
+              0,
+              0.447073474470735
+            ],
+            "gridcolor": "rgba(235,235,235,1)",
+            "gridwidth": 0.66417600664176,
+            "zeroline": false,
+            "anchor": "x",
+            "title": "",
+            "hoverformat": ".2f"
+          },
+          "showlegend": true,
+          "legend": {
+            "bgcolor": null,
+            "bordercolor": null,
+            "borderwidth": 0,
+            "font": {
+              "color": "rgba(0,0,0,1)",
+              "family": "Arial",
+              "size": 14
+            },
+            "y": -0.1,
+            "orientation": "h",
+            "x": 0.2
+          },
+          "hovermode": "closest",
+          "barmode": "relative",
+          "title": {
+            "text": "Chart showing the quality of new and existing school places and estimated additional places, by Local Authority compared to England",
+            "font": {
+              "color": "#ffffff"
+            }
+          }
+        },
+        "config": {
+          "doubleClick": "reset",
+          "showSendToCloud": false,
+          "displayModeBar": false
+        },
+        "source": "A",
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
+      },
+      "evals": [
+
+      ],
+      "jsHooks": [
+
+      ],
+      "deps": [
+        {
+          "name": "setprototypeof",
+          "version": "0.1",
+          "src": {
+            "href": "setprototypeof-0.1"
+          },
+          "meta": null,
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "crosstalk",
+          "version": "1.1.1",
+          "src": {
+            "href": "crosstalk-1.1.1"
+          },
+          "meta": null,
+          "script": "js/crosstalk.min.js",
+          "stylesheet": "css/crosstalk.css",
+          "head": null,
+          "attachment": null,
+          "all_files": true
+        },
+        {
+          "name": "plotly-htmlwidgets-css",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-htmlwidgets-css-1.57.1"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "plotly-main",
+          "version": "1.57.1",
+          "src": {
+            "href": "plotly-main-1.57.1"
+          },
+          "meta": null,
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        }
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/015.json
+++ b/tests/shinytest/UI_tests-current/015.json
@@ -1,0 +1,29 @@
+{
+  "input": {
+    "LA_choice": "Cheshire East",
+    "navbar": "la_scorecards",
+    "phase_choice": "Primary",
+    "tabs": "cost"
+  },
+  "output": {
+    "cost_table": "<table  class = 'table shiny-table table- spacing-s' style = 'width:auto;'>\n<thead> <tr> <th style='text-align: left;'> Type <\/th> <th style='text-align: left;'> England <\/th> <th style='text-align: left;'> North East <\/th>  <\/tr> <\/thead> <tbody>\n  <tr> <td> Permanent Expansion <\/td> <td> £17,268 <\/td> <td> £14,386 <\/td> <\/tr>\n  <tr> <td> Temporary Expansion <\/td> <td> £8,196 <\/td> <td> £3,026 <\/td> <\/tr>\n  <tr> <td> New school <\/td> <td> £20,508 <\/td> <td> - <\/td> <\/tr>\n   <\/tbody> <\/table>",
+    "new_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>0<\/h3>\n    <p>New primary schools projects in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "perm_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>9<\/h3>\n    <p>Permanent primary expansion projects in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "temp_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>1<\/h3>\n    <p>Temporary primary expansion projects in England <\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/016.json
+++ b/tests/shinytest/UI_tests-current/016.json
@@ -1,0 +1,29 @@
+{
+  "input": {
+    "LA_choice": "England",
+    "navbar": "la_scorecards",
+    "phase_choice": "Primary",
+    "tabs": "cost"
+  },
+  "output": {
+    "cost_table": "<table  class = 'table shiny-table table- spacing-s' style = 'width:auto;'>\n<thead> <tr> <th style='text-align: left;'> Type <\/th> <th style='text-align: left;'> England <\/th>  <\/tr> <\/thead> <tbody>\n  <tr> <td> Permanent Expansion <\/td> <td> £17,268 <\/td> <\/tr>\n  <tr> <td> Temporary Expansion <\/td> <td> £8,196 <\/td> <\/tr>\n  <tr> <td> New school <\/td> <td> £20,508 <\/td> <\/tr>\n   <\/tbody> <\/table>",
+    "new_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>70<\/h3>\n    <p>New primary schools projects in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "perm_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>1,204<\/h3>\n    <p>Permanent primary expansion projects in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "temp_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>616<\/h3>\n    <p>Temporary primary expansion projects in England <\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/017.json
+++ b/tests/shinytest/UI_tests-current/017.json
@@ -1,0 +1,29 @@
+{
+  "input": {
+    "LA_choice": "England",
+    "navbar": "la_scorecards",
+    "phase_choice": "Secondary",
+    "tabs": "cost"
+  },
+  "output": {
+    "cost_table": "<table  class = 'table shiny-table table- spacing-s' style = 'width:auto;'>\n<thead> <tr> <th style='text-align: left;'> Type <\/th> <th style='text-align: left;'> England <\/th>  <\/tr> <\/thead> <tbody>\n  <tr> <td> Permanent Expansion <\/td> <td> £23,775 <\/td> <\/tr>\n  <tr> <td> Temporary Expansion <\/td> <td> £9,248 <\/td> <\/tr>\n  <tr> <td> New school <\/td> <td> £24,929 <\/td> <\/tr>\n   <\/tbody> <\/table>",
+    "new_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>12<\/h3>\n    <p>New secondary schools projects in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "perm_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>144<\/h3>\n    <p>Permanent secondary expansion projects in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "temp_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>41<\/h3>\n    <p>Temporary secondary expansion projects in England <\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    }
+  }
+}

--- a/tests/shinytest/UI_tests-current/018.json
+++ b/tests/shinytest/UI_tests-current/018.json
@@ -1,0 +1,29 @@
+{
+  "input": {
+    "LA_choice": "England",
+    "navbar": "la_scorecards",
+    "phase_choice": "Secondary",
+    "tabs": "cost"
+  },
+  "output": {
+    "cost_table": "<table  class = 'table shiny-table table- spacing-s' style = 'width:auto;'>\n<thead> <tr> <th style='text-align: left;'> Type <\/th> <th style='text-align: left;'> England <\/th>  <\/tr> <\/thead> <tbody>\n  <tr> <td> Permanent Expansion <\/td> <td> £23,775 <\/td> <\/tr>\n  <tr> <td> Temporary Expansion <\/td> <td> £9,248 <\/td> <\/tr>\n  <tr> <td> New school <\/td> <td> £24,929 <\/td> <\/tr>\n   <\/tbody> <\/table>",
+    "new_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>12<\/h3>\n    <p>New secondary schools projects in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "perm_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>144<\/h3>\n    <p>Permanent secondary expansion projects in England<\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    },
+    "temp_box": {
+      "html": "<div class=\"small-box bg-light-blue\">\n  <div class=\"inner\">\n    <h3>41<\/h3>\n    <p>Temporary secondary expansion projects in England <\/p>\n  <\/div>\n<\/div>",
+      "deps": [
+
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Patch for issue #53 

None of the three tables were properly rendering in the markdown pdf download. Looks like it was just that kable wasn't recognising that it was supposed to be creating latex output for pdf, so was probably outputting some form of html based table. Have specifically set the output option in all three of the kable calls within the markdown to force them into outputting latex code. Have also added the booktabs flag to give the tables a nicer styling.

![image](https://user-images.githubusercontent.com/230859/175342858-19fbe647-9f4c-4df0-a0cc-3aa1368c1cfd.png)

![image](https://user-images.githubusercontent.com/230859/175342925-6fe5ce12-eed5-4650-a823-0d1b085e44da.png)
